### PR TITLE
Phase 1: Watcher with rename pairer

### DIFF
--- a/.claude/skills/homedrive-watcher-rename/SKILL.md
+++ b/.claude/skills/homedrive-watcher-rename/SKILL.md
@@ -50,15 +50,20 @@ preserving the cookie in `event.Op`.
 - **Conflict during rename**: if destination already exists remotely,
   apply the standard §11 conflict resolution at the directory level.
   Documented as a known v0.1 limitation.
-- **`IN_MOVE_SELF` fires after pairing**: when the source directory has
-  its own inotify watch, the kernel fires `IN_MOVE_SELF` on that watch
-  descriptor in addition to `IN_MOVED_FROM` on the parent. This produces
-  a second `Rename(srcDir)` event that can arrive **after** the pair
-  completes — at which point `srcDir` has been untracked by
-  `removeSubtreeWatches`. `isSuppressed` must match the directory path
-  itself, not only paths beneath it. `strings.HasPrefix(path, "srcDir/")`
-  silently misses `path == "srcDir"`. Fix: also check
-  `path == strings.TrimSuffix(prefix, string(filepath.Separator))`.
+- **`IN_MOVE_SELF` fires after pairing** (Linux only): when the source
+  directory has its own inotify watch, the kernel fires `IN_MOVE_SELF` on
+  that watch descriptor after `IN_MOVED_FROM`. This produces a second
+  `Rename(srcDir)` event that can arrive **after** the pair completes — at
+  which point `srcDir` has been untracked. `isSuppressed` must match the
+  directory path itself, not only paths beneath it:
+  `path == strings.TrimSuffix(prefix, sep) || strings.HasPrefix(path, prefix)`.
+- **Create arrives before Rename** (macOS/kqueue): on macOS, `NOTE_WRITE`
+  on the parent fires `Create(dst)` before `NOTE_RENAME` fires `Rename(src)`.
+  The pairer records the Create in `recentCreates` and the subsequent Rename
+  completes the pair. `onDirRenamePaired` must also call `debouncer.suppress(dr.To)`
+  to cancel the debounced Create event that was already queued. For large
+  directories (5k+ files), the kqueue backlog can delay the Rename by > 200ms;
+  tests must widen `DirRenamePairWindow` on non-Linux accordingly.
 
 ## Syncer behavior on `DirRename`
 
@@ -111,7 +116,9 @@ N transactions.
 - `isSuppressed(path)` must cover **both** the directory itself and its
   children: check `path == dirPath || strings.HasPrefix(path, dirPath+"/")`.
   Checking only the `dirPath + "/"` prefix misses the `IN_MOVE_SELF` event
-  on the directory's own wd.
+  on the directory's own wd (Linux) and any direct events on the dir itself.
+- On macOS, also call `debouncer.suppress(dr.To)` in `onDirRenamePaired` to
+  cancel the buffered `Create(dst)` that was queued before the pair completed.
 - When re-watching, do it in the order: remove old → add new. Brief
   window where events on the renamed subtree are dropped is acceptable
   given the suppression set.

--- a/.claude/skills/homedrive-watcher-rename/SKILL.md
+++ b/.claude/skills/homedrive-watcher-rename/SKILL.md
@@ -50,6 +50,15 @@ preserving the cookie in `event.Op`.
 - **Conflict during rename**: if destination already exists remotely,
   apply the standard §11 conflict resolution at the directory level.
   Documented as a known v0.1 limitation.
+- **`IN_MOVE_SELF` fires after pairing**: when the source directory has
+  its own inotify watch, the kernel fires `IN_MOVE_SELF` on that watch
+  descriptor in addition to `IN_MOVED_FROM` on the parent. This produces
+  a second `Rename(srcDir)` event that can arrive **after** the pair
+  completes — at which point `srcDir` has been untracked by
+  `removeSubtreeWatches`. `isSuppressed` must match the directory path
+  itself, not only paths beneath it. `strings.HasPrefix(path, "srcDir/")`
+  silently misses `path == "srcDir"`. Fix: also check
+  `path == strings.TrimSuffix(prefix, string(filepath.Separator))`.
 
 ## Syncer behavior on `DirRename`
 
@@ -93,11 +102,16 @@ N transactions.
 
 ## Implementation hints
 
-- Pair buffer keyed by cookie: `map[uint32]renameEntry` with a `time.Timer`
-  per entry for window expiry.
+- Pair buffer keyed by **path** (not cookie): `map[string]renameEntry`
+  with a `time.Timer` per entry for window expiry. The path key is the
+  old directory path as reported by fsnotify.
 - Use a mutex around the buffer; events arrive on the fsnotify goroutine.
 - The suppression set for child events expires when the pair completes
   (or shortly after, e.g. 100ms grace).
+- `isSuppressed(path)` must cover **both** the directory itself and its
+  children: check `path == dirPath || strings.HasPrefix(path, dirPath+"/")`.
+  Checking only the `dirPath + "/"` prefix misses the `IN_MOVE_SELF` event
+  on the directory's own wd.
 - When re-watching, do it in the order: remove old → add new. Brief
   window where events on the renamed subtree are dropped is acceptable
   given the suppression set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,16 @@ _ "github.com/rclone/rclone/backend/drive"
 
 ## Development environment
 
-Target is Linux ARM64; development is on macOS. fsnotify uses FSEvents on macOS (different semantics from inotify), so **watcher tests must run on Linux**. See `PLAN.md` §19 and `docs/dev-environment.md` for OrbStack setup, cross-compilation, build tags, and VS Code config.
+Target is Linux ARM64; development is on macOS. fsnotify uses FSEvents on macOS (different semantics from inotify), so **watcher tests must run on Linux**.
+
+This project uses **[OrbStack](https://orbstack.dev)** (not Docker Desktop) for the local Linux VM. OrbStack runs a fast, lightweight Ubuntu 24.04 VM (`dev` machine) with real inotify support. Always run watcher tests via `orb run -m dev -- ...` or `make test-linux`.
+
+Build pipeline order (never skip steps):
+1. `make test` — macOS native (catches compile errors, non-inotify tests)
+2. `orb run -m dev -- go test -race ./homedrive/...` — Linux VM (real inotify, race detector)
+3. Push to GitHub — CI validates on amd64 and arm64
+
+See `PLAN.md` §19 and `docs/dev-environment.md` for cross-compilation, build tags, and VS Code config.
 
 ## Skills and agent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,10 @@ Target is Linux ARM64; development is on macOS. fsnotify uses FSEvents on macOS 
 
 This project uses **[OrbStack](https://orbstack.dev)** (not Docker Desktop) for the local Linux VM. OrbStack runs a fast, lightweight Ubuntu 24.04 VM (`dev` machine) with real inotify support. Always run watcher tests via `orb run -m dev -- ...` or `make test-linux`.
 
-Build pipeline order (never skip steps):
-1. `make test` — macOS native (catches compile errors, non-inotify tests)
-2. `orb run -m dev -- go test -race ./homedrive/...` — Linux VM (real inotify, race detector)
-3. Push to GitHub — CI validates on amd64 and arm64
+Build pipeline order — run in this order, never skip, commit only after all pass:
+1. `make test` — macOS native: catches compile errors and all platform-agnostic tests including rename tests (rename pairer handles both inotify and kqueue event orderings)
+2. `orb run -m dev -- go test -race ./homedrive/...` — Linux VM: real inotify, IN_MOVE_SELF, race detector
+3. Commit and push — CI validates on amd64 and arm64
 
 See `PLAN.md` §19 and `docs/dev-environment.md` for cross-compilation, build tags, and VS Code config.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ contributions too.
 2. Branch: `phase-N-<short-title>`.
 3. Read the relevant skill(s) in `.claude/skills/`.
 4. Implement, with tests.
-5. Run locally inside OrbStack:
+5. Run locally inside OrbStack ([orbstack.dev](https://orbstack.dev)) —
+   the project requires real Linux inotify semantics not available on macOS:
    ```bash
    orb run -m dev -- go test -race ./homedrive/...
    ```

--- a/homedrive/PLAN.md
+++ b/homedrive/PLAN.md
@@ -642,19 +642,20 @@ Each phase = one PR, reviewed before the next. Issues created via
 - [x] Initial README + this `PLAN.md`.
 - Issue: `[homedrive] Bootstrap module`.
 
-### Phase 1 — Watcher with rename pairer (1.5d)
-- `internal/watcher/`: initial Walk, dynamic AddWatch on directory `Create`.
-- Per-path debouncer (configurable window).
-- **Directory rename pairer** (cookie-based, configurable window).
-- `doublestar` exclusion filters from config.
-- Outbound channel: `Event{Path, Op, At}` and `DirRename{From, To, At}`.
-- Unit tests:
-  - create, write, write x10 fast.
-  - mv dir small (10 files) → 1 paired event, child events suppressed.
-  - mv dir large (5k files in tests) → 1 paired event, < 100ms latency.
-  - mv across mount points → fallback to delete+create.
-  - rapid double rename within window → both pairs handled.
-  - rename of dir containing only excluded files → 1 paired event.
+### Phase 1 — Watcher with rename pairer (1.5d) [DONE]
+- [x] `internal/watcher/`: initial Walk, dynamic AddWatch on directory `Create`.
+- [x] Per-path debouncer (configurable window).
+- [x] **Directory rename pairer** (cookie-based, configurable window).
+- [x] `doublestar` exclusion filters from config.
+- [x] Inode/mtime guard — consult store before emitting (1s tolerance).
+- [x] Outbound channel: `Event{Path, Op, At}` and `DirRename{From, To, At}`.
+- [x] Unit tests:
+  - [x] create, write, write x10 fast → debounced to 1 event.
+  - [x] mv dir small (10 files) → 1 paired event, child events suppressed.
+  - [x] mv dir large (5k files in tests) → 1 paired event, < 100ms latency.
+  - [x] mv across mount points → fallback to delete+create.
+  - [x] rapid double rename within window → both pairs handled.
+  - [x] rename of dir containing only excluded files → 1 paired event.
 - Issue: `[homedrive] Watcher fsnotify + rename pairer`.
 
 ### Phase 2 — Minimal rclone wrapper (1d)

--- a/homedrive/go.mod
+++ b/homedrive/go.mod
@@ -2,9 +2,14 @@ module github.com/asnowfix/home-drive/homedrive
 
 go 1.26.2
 
-require github.com/spf13/cobra v1.9.1
+require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/spf13/cobra v1.9.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/homedrive/go.sum
+++ b/homedrive/go.sum
@@ -1,4 +1,8 @@
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -6,5 +10,7 @@ github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/homedrive/internal/watcher/debouncer.go
+++ b/homedrive/internal/watcher/debouncer.go
@@ -39,7 +39,7 @@ func (d *debouncer) add(ev Event) {
 
 	// Update the pending event. Don't downgrade Create → Write: os.WriteFile
 	// fires IN_CREATE then IN_MODIFY in rapid succession; the Create must win.
-	if existing, ok := d.pending[path]; !(ok && existing.Op == OpCreate && ev.Op == OpWrite) {
+	if existing, ok := d.pending[path]; !ok || existing.Op != OpCreate || ev.Op != OpWrite {
 		d.pending[path] = ev
 	}
 

--- a/homedrive/internal/watcher/debouncer.go
+++ b/homedrive/internal/watcher/debouncer.go
@@ -39,7 +39,7 @@ func (d *debouncer) add(ev Event) {
 
 	// Update the pending event. Don't downgrade Create → Write: os.WriteFile
 	// fires IN_CREATE then IN_MODIFY in rapid succession; the Create must win.
-	if existing, ok := d.pending[path]; !ok || !(existing.Op == OpCreate && ev.Op == OpWrite) {
+	if existing, ok := d.pending[path]; !(ok && existing.Op == OpCreate && ev.Op == OpWrite) {
 		d.pending[path] = ev
 	}
 

--- a/homedrive/internal/watcher/debouncer.go
+++ b/homedrive/internal/watcher/debouncer.go
@@ -37,8 +37,11 @@ func (d *debouncer) add(ev Event) {
 
 	path := ev.Path
 
-	// Update the pending event (always keep the latest).
-	d.pending[path] = ev
+	// Update the pending event. Don't downgrade Create → Write: os.WriteFile
+	// fires IN_CREATE then IN_MODIFY in rapid succession; the Create must win.
+	if existing, ok := d.pending[path]; !ok || !(existing.Op == OpCreate && ev.Op == OpWrite) {
+		d.pending[path] = ev
+	}
 
 	// If there is an existing timer, stop and reset it.
 	if t, ok := d.timers[path]; ok {

--- a/homedrive/internal/watcher/debouncer.go
+++ b/homedrive/internal/watcher/debouncer.go
@@ -1,0 +1,102 @@
+package watcher
+
+import (
+	"sync"
+	"time"
+)
+
+// debouncer coalesces rapid file system events per path. Each event resets
+// the path's timer; the callback fires only after the debounce window
+// elapses with no new events for that path.
+type debouncer struct {
+	mu     sync.Mutex
+	window time.Duration
+	timers map[string]*time.Timer
+	// pending tracks the latest event per path during the debounce window.
+	pending map[string]Event
+	// emit is called when the debounce window expires for a path.
+	emit func(Event)
+}
+
+// newDebouncer creates a debouncer with the given window and emission callback.
+func newDebouncer(window time.Duration, emit func(Event)) *debouncer {
+	return &debouncer{
+		window:  window,
+		timers:  make(map[string]*time.Timer),
+		pending: make(map[string]Event),
+		emit:    emit,
+	}
+}
+
+// add registers or resets a debounce timer for the given event. If a timer
+// already exists for the path, it is stopped and reset. The latest event's
+// Op and At are preserved for emission.
+func (d *debouncer) add(ev Event) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	path := ev.Path
+
+	// Update the pending event (always keep the latest).
+	d.pending[path] = ev
+
+	// If there is an existing timer, stop and reset it.
+	if t, ok := d.timers[path]; ok {
+		t.Stop()
+	}
+
+	d.timers[path] = time.AfterFunc(d.window, func() {
+		d.mu.Lock()
+		pending, ok := d.pending[path]
+		if ok {
+			delete(d.pending, path)
+			delete(d.timers, path)
+		}
+		d.mu.Unlock()
+
+		if ok {
+			d.emit(pending)
+		}
+	})
+}
+
+// suppress cancels any pending debounce for the given path. This is used
+// when a directory rename is paired and child events should be dropped.
+func (d *debouncer) suppress(path string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if t, ok := d.timers[path]; ok {
+		t.Stop()
+		delete(d.timers, path)
+		delete(d.pending, path)
+	}
+}
+
+// suppressPrefix cancels all pending debounces whose paths start with the
+// given prefix. Used when a directory rename pairs and all child events
+// within the renamed subtree should be dropped.
+func (d *debouncer) suppressPrefix(prefix string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for path, t := range d.timers {
+		if len(path) >= len(prefix) && path[:len(prefix)] == prefix {
+			t.Stop()
+			delete(d.timers, path)
+			delete(d.pending, path)
+		}
+	}
+}
+
+// stop cancels all pending timers. Must be called during shutdown.
+func (d *debouncer) stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for path, t := range d.timers {
+		t.Stop()
+		delete(d.timers, path)
+		delete(d.pending, path)
+	}
+}

--- a/homedrive/internal/watcher/debouncer_test.go
+++ b/homedrive/internal/watcher/debouncer_test.go
@@ -1,0 +1,195 @@
+package watcher
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDebouncer_SingleEvent(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(50*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	d.add(Event{Path: "/tmp/file.txt", Op: OpWrite, At: time.Now()})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(received))
+	}
+	if received[0].Path != "/tmp/file.txt" {
+		t.Errorf("expected path /tmp/file.txt, got %s", received[0].Path)
+	}
+}
+
+func TestDebouncer_MultipleWritesCoalesced(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(100*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	// Send 10 rapid write events on the same path.
+	for i := 0; i < 10; i++ {
+		d.add(Event{
+			Path: "/tmp/file.txt",
+			Op:   OpWrite,
+			At:   time.Now(),
+		})
+		time.Sleep(10 * time.Millisecond) // 10ms apart, well within 100ms window
+	}
+
+	// Wait for debounce to expire (100ms after last event + margin).
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 debounced event, got %d", len(received))
+	}
+}
+
+func TestDebouncer_DifferentPathsIndependent(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(50*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	d.add(Event{Path: "/tmp/a.txt", Op: OpWrite, At: time.Now()})
+	d.add(Event{Path: "/tmp/b.txt", Op: OpWrite, At: time.Now()})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 2 {
+		t.Fatalf("expected 2 events (one per path), got %d", len(received))
+	}
+
+	paths := map[string]bool{}
+	for _, ev := range received {
+		paths[ev.Path] = true
+	}
+	if !paths["/tmp/a.txt"] || !paths["/tmp/b.txt"] {
+		t.Errorf("expected events for both paths, got %v", paths)
+	}
+}
+
+func TestDebouncer_SuppressPath(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(50*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	d.add(Event{Path: "/tmp/file.txt", Op: OpWrite, At: time.Now()})
+	d.suppress("/tmp/file.txt")
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 0 {
+		t.Fatalf("expected 0 events after suppress, got %d", len(received))
+	}
+}
+
+func TestDebouncer_SuppressPrefix(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(100*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	d.add(Event{Path: "/tmp/dir/a.txt", Op: OpCreate, At: time.Now()})
+	d.add(Event{Path: "/tmp/dir/b.txt", Op: OpCreate, At: time.Now()})
+	d.add(Event{Path: "/tmp/other.txt", Op: OpCreate, At: time.Now()})
+
+	d.suppressPrefix("/tmp/dir/")
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 event (only /tmp/other.txt), got %d", len(received))
+	}
+	if received[0].Path != "/tmp/other.txt" {
+		t.Errorf("expected /tmp/other.txt, got %s", received[0].Path)
+	}
+}
+
+func TestDebouncer_Stop(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(100*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+
+	d.add(Event{Path: "/tmp/file.txt", Op: OpWrite, At: time.Now()})
+	d.stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 0 {
+		t.Fatalf("expected 0 events after stop, got %d", len(received))
+	}
+}
+
+func TestDebouncer_KeepsLatestOp(t *testing.T) {
+	var mu sync.Mutex
+	var received []Event
+
+	d := newDebouncer(50*time.Millisecond, func(ev Event) {
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+	})
+	defer d.stop()
+
+	// First event is Create, second is Write. Debouncer should keep the latest.
+	d.add(Event{Path: "/tmp/file.txt", Op: OpCreate, At: time.Now()})
+	d.add(Event{Path: "/tmp/file.txt", Op: OpWrite, At: time.Now()})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(received))
+	}
+	if received[0].Op != OpWrite {
+		t.Errorf("expected OpWrite (latest), got %v", received[0].Op)
+	}
+}

--- a/homedrive/internal/watcher/debouncer_test.go
+++ b/homedrive/internal/watcher/debouncer_test.go
@@ -167,7 +167,7 @@ func TestDebouncer_Stop(t *testing.T) {
 	}
 }
 
-func TestDebouncer_KeepsLatestOp(t *testing.T) {
+func TestDebouncer_CreateNotDowngradedToWrite(t *testing.T) {
 	var mu sync.Mutex
 	var received []Event
 
@@ -178,7 +178,8 @@ func TestDebouncer_KeepsLatestOp(t *testing.T) {
 	})
 	defer d.stop()
 
-	// First event is Create, second is Write. Debouncer should keep the latest.
+	// os.WriteFile fires IN_CREATE then IN_MODIFY in quick succession.
+	// Create must not be downgraded to Write.
 	d.add(Event{Path: "/tmp/file.txt", Op: OpCreate, At: time.Now()})
 	d.add(Event{Path: "/tmp/file.txt", Op: OpWrite, At: time.Now()})
 
@@ -189,7 +190,7 @@ func TestDebouncer_KeepsLatestOp(t *testing.T) {
 	if len(received) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(received))
 	}
-	if received[0].Op != OpWrite {
-		t.Errorf("expected OpWrite (latest), got %v", received[0].Op)
+	if received[0].Op != OpCreate {
+		t.Errorf("expected OpCreate (not downgraded to Write), got %v", received[0].Op)
 	}
 }

--- a/homedrive/internal/watcher/errors.go
+++ b/homedrive/internal/watcher/errors.go
@@ -1,0 +1,9 @@
+package watcher
+
+import "errors"
+
+// Sentinel errors for the watcher package.
+var (
+	// ErrInvalidConfig indicates a configuration value is missing or invalid.
+	ErrInvalidConfig = errors.New("watcher: invalid configuration")
+)

--- a/homedrive/internal/watcher/filter.go
+++ b/homedrive/internal/watcher/filter.go
@@ -1,0 +1,58 @@
+package watcher
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// filter evaluates doublestar exclusion patterns against paths relative to
+// a root directory. Patterns are checked at watch-add time and at event
+// emission time (defense in depth).
+type filter struct {
+	root     string
+	patterns []string
+}
+
+// newFilter creates a filter with the given root and exclusion patterns.
+func newFilter(root string, patterns []string) *filter {
+	return &filter{
+		root:     filepath.Clean(root),
+		patterns: patterns,
+	}
+}
+
+// excluded returns true if the absolute path matches any exclusion pattern.
+func (f *filter) excluded(absPath string) bool {
+	if len(f.patterns) == 0 {
+		return false
+	}
+
+	rel, err := filepath.Rel(f.root, absPath)
+	if err != nil {
+		return false
+	}
+	// Normalize to forward slashes for doublestar matching.
+	rel = filepath.ToSlash(rel)
+
+	for _, pattern := range f.patterns {
+		// Match against the relative path.
+		if matched, _ := doublestar.Match(pattern, rel); matched {
+			return true
+		}
+		// Also try matching with a trailing slash for directory patterns.
+		if matched, _ := doublestar.Match(pattern, rel+"/"); matched {
+			return true
+		}
+		// For patterns like "**/.git/**", check if the path is a prefix
+		// that would match (e.g. ".git" itself matches "**/.git/**").
+		if strings.HasSuffix(pattern, "/**") {
+			dirPattern := strings.TrimSuffix(pattern, "/**")
+			if matched, _ := doublestar.Match(dirPattern, rel); matched {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/homedrive/internal/watcher/filter_test.go
+++ b/homedrive/internal/watcher/filter_test.go
@@ -1,0 +1,88 @@
+package watcher
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFilter_Excluded(t *testing.T) {
+	root := "/mnt/external/gdrive"
+
+	tests := []struct {
+		name     string
+		patterns []string
+		path     string
+		want     bool
+	}{
+		{
+			name:     "GitDirectory",
+			patterns: []string{"**/.git/**"},
+			path:     filepath.Join(root, "project/.git/HEAD"),
+			want:     true,
+		},
+		{
+			name:     "GitDirectoryItself",
+			patterns: []string{"**/.git/**"},
+			path:     filepath.Join(root, "project/.git"),
+			want:     true,
+		},
+		{
+			name:     "DSStore",
+			patterns: []string{"**/.DS_Store"},
+			path:     filepath.Join(root, "Documents/.DS_Store"),
+			want:     true,
+		},
+		{
+			name:     "VimSwap",
+			patterns: []string{"**/*.swp"},
+			path:     filepath.Join(root, "docs/.readme.swp"),
+			want:     true,
+		},
+		{
+			name:     "NodeModules",
+			patterns: []string{"**/node_modules/**"},
+			path:     filepath.Join(root, "app/node_modules/lodash/index.js"),
+			want:     true,
+		},
+		{
+			name:     "NormalFile",
+			patterns: []string{"**/.git/**", "**/*.swp"},
+			path:     filepath.Join(root, "Documents/notes.md"),
+			want:     false,
+		},
+		{
+			name:     "NoPatterns",
+			patterns: nil,
+			path:     filepath.Join(root, "anything.txt"),
+			want:     false,
+		},
+		{
+			name:     "TmpFile",
+			patterns: []string{"**/*.tmp"},
+			path:     filepath.Join(root, "download.tmp"),
+			want:     true,
+		},
+		{
+			name:     "TildeBackup",
+			patterns: []string{"**/*~"},
+			path:     filepath.Join(root, "file.txt~"),
+			want:     true,
+		},
+		{
+			name:     "IdeaDirectory",
+			patterns: []string{"**/.idea/**"},
+			path:     filepath.Join(root, "project/.idea/workspace.xml"),
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFilter(root, tt.patterns)
+			got := f.excluded(tt.path)
+			if got != tt.want {
+				t.Errorf("excluded(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/homedrive/internal/watcher/helpers_test.go
+++ b/homedrive/internal/watcher/helpers_test.go
@@ -1,0 +1,110 @@
+package watcher
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+// stubStore implements SyncStore for testing the mtime guard.
+type stubStore struct {
+	records map[string]*SyncRecord
+}
+
+func (s *stubStore) GetSyncRecord(path string) *SyncRecord {
+	if s == nil || s.records == nil {
+		return nil
+	}
+	return s.records[path]
+}
+
+// newTestWatcher creates a Watcher for testing with a temp directory and
+// short debounce/pair windows.
+func newTestWatcher(t *testing.T, opts ...func(*Config)) (*Watcher, string) {
+	t.Helper()
+	root := t.TempDir()
+
+	cfg := Config{
+		LocalRoot:           root,
+		Debounce:            100 * time.Millisecond,
+		DirRenamePairWindow: 200 * time.Millisecond,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	w, err := New(cfg, nil, log)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+
+	return w, root
+}
+
+// startWatcher starts the watcher in a goroutine and returns a cancel func.
+func startWatcher(t *testing.T, w *Watcher) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		if err := w.Start(ctx); err != nil && err != context.Canceled {
+			t.Logf("watcher.Start returned: %v", err)
+		}
+	}()
+
+	// Give the watcher time to set up watches.
+	time.Sleep(50 * time.Millisecond)
+
+	t.Cleanup(func() {
+		cancel()
+		w.Stop()
+	})
+
+	return cancel
+}
+
+// collectEvents reads events from the watcher channel with a timeout.
+func collectEvents(t *testing.T, w *Watcher, timeout time.Duration) []WatchEvent {
+	t.Helper()
+	var events []WatchEvent
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev := <-w.Events():
+			events = append(events, ev)
+		case <-deadline:
+			return events
+		}
+	}
+}
+
+// waitForEvent reads one event from the watcher channel with a timeout.
+func waitForEvent(t *testing.T, w *Watcher, timeout time.Duration) (WatchEvent, bool) {
+	t.Helper()
+	select {
+	case ev := <-w.Events():
+		return ev, true
+	case <-time.After(timeout):
+		return WatchEvent{}, false
+	}
+}
+
+// intToStr converts an integer to a string without importing strconv
+// to keep test dependencies minimal.
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/homedrive/internal/watcher/pairer.go
+++ b/homedrive/internal/watcher/pairer.go
@@ -19,17 +19,22 @@ type renameEntry struct {
 
 // pairer detects directory renames by matching Rename events with
 // subsequent Create events within a configurable time window. On Linux,
-// inotify guarantees that IN_MOVED_FROM and IN_MOVED_TO with the same
-// cookie arrive sequentially; fsnotify translates these into Rename and
-// Create events. The pairer buffers Rename events on watched directories
-// and pairs them with the next Create event for a directory.
+// inotify guarantees that IN_MOVED_FROM and IN_MOVED_TO arrive in order;
+// on macOS/kqueue the Create(dst) can arrive before the Rename(src). Both
+// orderings are handled via the pending and recentCreates maps.
 type pairer struct {
 	mu     sync.Mutex
 	window time.Duration
 	log    *slog.Logger
 
 	// pending maps old directory paths to their rename entries.
+	// Used on Linux/inotify where Rename arrives before Create.
 	pending map[string]*renameEntry
+
+	// recentCreates records directory Create events that arrived before any
+	// matching Rename (macOS/kqueue path). Keyed by the new directory path,
+	// value is the event time. Entries are lazily expired by handleRename.
+	recentCreates map[string]time.Time
 
 	// suppressedPrefixes tracks directory paths that have been paired.
 	// Child events under these prefixes are suppressed for the duration
@@ -54,6 +59,7 @@ func newPairer(window time.Duration, log *slog.Logger, onPair func(DirRename), o
 		window:             window,
 		log:                log,
 		pending:            make(map[string]*renameEntry),
+		recentCreates:      make(map[string]time.Time),
 		suppressedPrefixes: make(map[string]time.Time),
 		onPair:             onPair,
 		onUnpaired:         onUnpaired,
@@ -85,9 +91,11 @@ func (p *pairer) isTrackedDir(path string) bool {
 	return ok
 }
 
-// handleRename buffers a Rename event for a directory. If the path was
-// a watched directory, it becomes a candidate for pairing. Returns true
-// if the event was buffered (caller should not emit it yet).
+// handleRename buffers a Rename event for a directory. It first checks
+// recentCreates for a reverse match (macOS/kqueue: Create arrived before
+// Rename). If found, the pair is completed immediately. Otherwise the
+// Rename is buffered for the pair window. Returns true if the event was
+// consumed (caller should not emit it).
 func (p *pairer) handleRename(path string, at time.Time) bool {
 	if !p.isTrackedDir(path) {
 		return false
@@ -96,6 +104,43 @@ func (p *pairer) handleRename(path string, at time.Time) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// Check for a Create that arrived before this Rename (macOS/kqueue path).
+	// Pick the oldest recent create within the pair window.
+	cutoff := at.Add(-p.window)
+	var matchDst string
+	var matchAt time.Time
+	for dstPath, createAt := range p.recentCreates {
+		if createAt.Before(cutoff) {
+			delete(p.recentCreates, dstPath) // lazy expiry
+			continue
+		}
+		if matchDst == "" || createAt.Before(matchAt) {
+			matchDst = dstPath
+			matchAt = createAt
+		}
+	}
+
+	if matchDst != "" {
+		delete(p.recentCreates, matchDst)
+
+		suppressUntil := time.Now().Add(p.window)
+		p.suppressedPrefixes[path+string(filepath.Separator)] = suppressUntil
+		p.suppressedPrefixes[matchDst+string(filepath.Separator)] = suppressUntil
+
+		p.log.Info("directory rename paired (reverse)",
+			"from", path,
+			"to", matchDst,
+			"op", "dir_rename",
+		)
+
+		dr := DirRename{From: path, To: matchDst, At: at}
+		p.mu.Unlock()
+		p.onPair(dr)
+		p.mu.Lock()
+		return true
+	}
+
+	// No recent Create found; buffer the Rename (Linux/inotify path).
 	entry := &renameEntry{path: path, at: at}
 	entry.timer = time.AfterFunc(p.window, func() {
 		p.expireRename(path)
@@ -111,8 +156,10 @@ func (p *pairer) handleRename(path string, at time.Time) bool {
 }
 
 // handleCreate checks if a Create event on a directory matches a pending
-// Rename. If so, the pair is emitted and child suppression begins.
-// Returns true if the event was consumed by pairing.
+// Rename (Linux/inotify path). If so, the pair is emitted. If no pending
+// Rename exists, the Create is recorded in recentCreates for reverse
+// matching when the Rename arrives later (macOS/kqueue path).
+// Returns true only when the event is fully consumed by a forward pair.
 func (p *pairer) handleCreate(path string, at time.Time) bool {
 	// Check if the created path is a directory.
 	info, err := os.Stat(path)
@@ -123,10 +170,8 @@ func (p *pairer) handleCreate(path string, at time.Time) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Look for the best matching pending rename. On Linux, the inotify
-	// events arrive in order, so there is typically exactly one pending
-	// rename. We match the oldest pending rename since it should be the
-	// one that pairs with this Create.
+	// Look for the best matching pending rename (forward pair: Rename before
+	// Create). Match the oldest pending rename.
 	var matchKey string
 	var matchEntry *renameEntry
 
@@ -138,10 +183,17 @@ func (p *pairer) handleCreate(path string, at time.Time) bool {
 	}
 
 	if matchEntry == nil {
+		// No pending Rename yet. Record this Create so that a subsequent
+		// Rename can pair with it (reverse pair: Create before Rename).
+		p.recentCreates[path] = at
+		p.log.Debug("create recorded for reverse pairing",
+			"path", path,
+			"window", p.window.String(),
+		)
 		return false
 	}
 
-	// Found a pair.
+	// Found a forward pair.
 	matchEntry.timer.Stop()
 	delete(p.pending, matchKey)
 
@@ -226,4 +278,5 @@ func (p *pairer) stop() {
 		delete(p.pending, path)
 	}
 	p.suppressedPrefixes = make(map[string]time.Time)
+	p.recentCreates = make(map[string]time.Time)
 }

--- a/homedrive/internal/watcher/pairer.go
+++ b/homedrive/internal/watcher/pairer.go
@@ -1,0 +1,226 @@
+package watcher
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// renameEntry records a buffered directory Rename event waiting for a
+// matching Create to arrive within the pair window.
+type renameEntry struct {
+	path  string
+	at    time.Time
+	timer *time.Timer
+}
+
+// pairer detects directory renames by matching Rename events with
+// subsequent Create events within a configurable time window. On Linux,
+// inotify guarantees that IN_MOVED_FROM and IN_MOVED_TO with the same
+// cookie arrive sequentially; fsnotify translates these into Rename and
+// Create events. The pairer buffers Rename events on watched directories
+// and pairs them with the next Create event for a directory.
+type pairer struct {
+	mu     sync.Mutex
+	window time.Duration
+	log    *slog.Logger
+
+	// pending maps old directory paths to their rename entries.
+	pending map[string]*renameEntry
+
+	// suppressedPrefixes tracks directory paths that have been paired.
+	// Child events under these prefixes are suppressed for the duration
+	// of the pair window to avoid redundant per-file events.
+	suppressedPrefixes map[string]time.Time
+
+	// onPair is called when a directory rename pair is detected.
+	onPair func(DirRename)
+
+	// onUnpaired is called when a Rename expires without a match (fallback
+	// to delete handling).
+	onUnpaired func(Event)
+
+	// watchedDirs tracks which paths had watches, so we can identify
+	// whether a Rename event is for a directory we were watching.
+	watchedDirs map[string]struct{}
+}
+
+// newPairer creates a rename pairer with the given window and callbacks.
+func newPairer(window time.Duration, log *slog.Logger, onPair func(DirRename), onUnpaired func(Event)) *pairer {
+	return &pairer{
+		window:             window,
+		log:                log,
+		pending:            make(map[string]*renameEntry),
+		suppressedPrefixes: make(map[string]time.Time),
+		onPair:             onPair,
+		onUnpaired:         onUnpaired,
+		watchedDirs:        make(map[string]struct{}),
+	}
+}
+
+// trackDir registers a directory path as being watched. This is needed
+// to determine whether a Rename event is for a directory (eligible for
+// pairing) or a file (handled normally).
+func (p *pairer) trackDir(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.watchedDirs[path] = struct{}{}
+}
+
+// untrackDir removes a directory from the tracked set.
+func (p *pairer) untrackDir(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.watchedDirs, path)
+}
+
+// isTrackedDir checks if a path was a watched directory.
+func (p *pairer) isTrackedDir(path string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.watchedDirs[path]
+	return ok
+}
+
+// handleRename buffers a Rename event for a directory. If the path was
+// a watched directory, it becomes a candidate for pairing. Returns true
+// if the event was buffered (caller should not emit it yet).
+func (p *pairer) handleRename(path string, at time.Time) bool {
+	if !p.isTrackedDir(path) {
+		return false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry := &renameEntry{path: path, at: at}
+	entry.timer = time.AfterFunc(p.window, func() {
+		p.expireRename(path)
+	})
+
+	p.pending[path] = entry
+
+	p.log.Debug("rename buffered for pairing",
+		"path", path,
+		"window", p.window.String(),
+	)
+	return true
+}
+
+// handleCreate checks if a Create event on a directory matches a pending
+// Rename. If so, the pair is emitted and child suppression begins.
+// Returns true if the event was consumed by pairing.
+func (p *pairer) handleCreate(path string, at time.Time) bool {
+	// Check if the created path is a directory.
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Look for the best matching pending rename. On Linux, the inotify
+	// events arrive in order, so there is typically exactly one pending
+	// rename. We match the oldest pending rename since it should be the
+	// one that pairs with this Create.
+	var matchKey string
+	var matchEntry *renameEntry
+
+	for key, entry := range p.pending {
+		if matchEntry == nil || entry.at.Before(matchEntry.at) {
+			matchKey = key
+			matchEntry = entry
+		}
+	}
+
+	if matchEntry == nil {
+		return false
+	}
+
+	// Found a pair.
+	matchEntry.timer.Stop()
+	delete(p.pending, matchKey)
+
+	// Set up child event suppression for both the old and new paths.
+	suppressUntil := time.Now().Add(p.window)
+	p.suppressedPrefixes[matchKey+string(filepath.Separator)] = suppressUntil
+	p.suppressedPrefixes[path+string(filepath.Separator)] = suppressUntil
+
+	p.log.Info("directory rename paired",
+		"from", matchKey,
+		"to", path,
+		"op", "dir_rename",
+	)
+
+	dr := DirRename{
+		From: matchKey,
+		To:   path,
+		At:   at,
+	}
+
+	// Release lock before calling back.
+	p.mu.Unlock()
+	p.onPair(dr)
+	p.mu.Lock()
+
+	return true
+}
+
+// isSuppressed returns true if the path falls under a recently-paired
+// directory rename and should be silently dropped.
+func (p *pairer) isSuppressed(path string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	for prefix, until := range p.suppressedPrefixes {
+		if now.After(until) {
+			delete(p.suppressedPrefixes, prefix)
+			continue
+		}
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// expireRename is called when the pair window expires without a match.
+// It falls back to standard delete handling for the renamed path.
+func (p *pairer) expireRename(path string) {
+	p.mu.Lock()
+	entry, ok := p.pending[path]
+	if !ok {
+		p.mu.Unlock()
+		return
+	}
+	delete(p.pending, path)
+	p.mu.Unlock()
+
+	p.log.Debug("rename unpaired, falling back to delete",
+		"path", path,
+		"op", "rename",
+	)
+
+	p.onUnpaired(Event{
+		Path: path,
+		Op:   OpRename,
+		At:   entry.at,
+	})
+}
+
+// stop cancels all pending pair timers.
+func (p *pairer) stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for path, entry := range p.pending {
+		entry.timer.Stop()
+		delete(p.pending, path)
+	}
+	p.suppressedPrefixes = make(map[string]time.Time)
+}

--- a/homedrive/internal/watcher/pairer.go
+++ b/homedrive/internal/watcher/pairer.go
@@ -182,7 +182,10 @@ func (p *pairer) isSuppressed(path string) bool {
 			delete(p.suppressedPrefixes, prefix)
 			continue
 		}
-		if strings.HasPrefix(path, prefix) {
+		// Also match the directory itself (IN_MOVE_SELF fires a Rename on
+		// the dir's own wd after the pair completes and the dir is untracked).
+		dirPath := strings.TrimSuffix(prefix, string(filepath.Separator))
+		if path == dirPath || strings.HasPrefix(path, prefix) {
 			return true
 		}
 	}

--- a/homedrive/internal/watcher/pairer_test.go
+++ b/homedrive/internal/watcher/pairer_test.go
@@ -1,0 +1,211 @@
+package watcher
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPairer_PairDirectoryRename(t *testing.T) {
+	// Create a real directory that the pairer can stat.
+	tmpDir := t.TempDir()
+	srcDir := tmpDir + "/src"
+	dstDir := tmpDir + "/dst"
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+
+	var mu sync.Mutex
+	var paired []DirRename
+	var unpaired []Event
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		500*time.Millisecond,
+		log,
+		func(dr DirRename) {
+			mu.Lock()
+			paired = append(paired, dr)
+			mu.Unlock()
+		},
+		func(ev Event) {
+			mu.Lock()
+			unpaired = append(unpaired, ev)
+			mu.Unlock()
+		},
+	)
+	defer p.stop()
+
+	// Track the source directory.
+	p.trackDir(srcDir)
+
+	// Simulate rename event (buffer it).
+	now := time.Now()
+	handled := p.handleRename(srcDir, now)
+	if !handled {
+		t.Fatal("expected handleRename to return true for tracked dir")
+	}
+
+	// Rename the actual directory so os.Stat in handleCreate works.
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	// Simulate create event (should pair).
+	consumed := p.handleCreate(dstDir, now)
+	if !consumed {
+		t.Fatal("expected handleCreate to return true for paired rename")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paired) != 1 {
+		t.Fatalf("expected 1 paired event, got %d", len(paired))
+	}
+	if paired[0].From != srcDir {
+		t.Errorf("From = %q, want %q", paired[0].From, srcDir)
+	}
+	if paired[0].To != dstDir {
+		t.Errorf("To = %q, want %q", paired[0].To, dstDir)
+	}
+}
+
+func TestPairer_UnpairedExpiry(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := tmpDir + "/expiring"
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	var unpaired []Event
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		100*time.Millisecond,
+		log,
+		func(dr DirRename) {
+			t.Error("unexpected pair callback")
+		},
+		func(ev Event) {
+			mu.Lock()
+			unpaired = append(unpaired, ev)
+			mu.Unlock()
+		},
+	)
+	defer p.stop()
+
+	p.trackDir(srcDir)
+	p.handleRename(srcDir, time.Now())
+
+	// Wait for the pair window to expire.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(unpaired) != 1 {
+		t.Fatalf("expected 1 unpaired event, got %d", len(unpaired))
+	}
+	if unpaired[0].Path != srcDir {
+		t.Errorf("Path = %q, want %q", unpaired[0].Path, srcDir)
+	}
+}
+
+func TestPairer_NonTrackedDirIgnored(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		500*time.Millisecond,
+		log,
+		func(dr DirRename) { t.Error("unexpected pair") },
+		func(ev Event) { t.Error("unexpected unpaired") },
+	)
+	defer p.stop()
+
+	// handleRename on a non-tracked path should return false.
+	if p.handleRename("/not/tracked", time.Now()) {
+		t.Error("expected handleRename to return false for non-tracked path")
+	}
+}
+
+func TestPairer_ChildSuppression(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := tmpDir + "/parent"
+	dstDir := tmpDir + "/parent_renamed"
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		500*time.Millisecond,
+		log,
+		func(dr DirRename) {},
+		func(ev Event) {},
+	)
+	defer p.stop()
+
+	p.trackDir(srcDir)
+	p.handleRename(srcDir, time.Now())
+
+	// Rename for real so handleCreate can stat.
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	p.handleCreate(dstDir, time.Now())
+
+	// After pairing, child events under both old and new paths should
+	// be suppressed.
+	if !p.isSuppressed(srcDir + "/child.txt") {
+		t.Error("expected child under old path to be suppressed")
+	}
+	if !p.isSuppressed(dstDir + "/child.txt") {
+		t.Error("expected child under new path to be suppressed")
+	}
+
+	// A path outside the renamed directory should not be suppressed.
+	if p.isSuppressed(tmpDir + "/other.txt") {
+		t.Error("expected path outside renamed dir to NOT be suppressed")
+	}
+}
+
+func TestPairer_HandleCreateForFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a regular file (not a directory).
+	filePath := tmpDir + "/regular.txt"
+	if err := os.WriteFile(filePath, []byte("data"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		500*time.Millisecond,
+		log,
+		func(dr DirRename) { t.Error("unexpected pair for file") },
+		func(ev Event) {},
+	)
+	defer p.stop()
+
+	// handleCreate should return false for a regular file.
+	if p.handleCreate(filePath, time.Now()) {
+		t.Error("expected handleCreate to return false for a regular file")
+	}
+}

--- a/homedrive/internal/watcher/pairer_test.go
+++ b/homedrive/internal/watcher/pairer_test.go
@@ -183,6 +183,67 @@ func TestPairer_ChildSuppression(t *testing.T) {
 	}
 }
 
+func TestPairer_ReversePair(t *testing.T) {
+	// On macOS/kqueue Create(dst) can arrive before Rename(src). Verify that
+	// handleCreate records the create and handleRename completes the pair.
+	tmpDir := t.TempDir()
+	srcDir := tmpDir + "/src"
+	dstDir := tmpDir + "/dst"
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	var mu sync.Mutex
+	var paired []DirRename
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	p := newPairer(
+		500*time.Millisecond,
+		log,
+		func(dr DirRename) {
+			mu.Lock()
+			paired = append(paired, dr)
+			mu.Unlock()
+		},
+		func(ev Event) { t.Errorf("unexpected unpaired event: %v", ev) },
+	)
+	defer p.stop()
+
+	p.trackDir(srcDir)
+	now := time.Now()
+
+	// Create arrives first (macOS order). Should return false so the watcher
+	// adds watches and debounces the event normally.
+	consumed := p.handleCreate(dstDir, now)
+	if consumed {
+		t.Fatal("handleCreate should return false for reverse-pair buffering")
+	}
+
+	// Rename arrives after Create.
+	handled := p.handleRename(srcDir, now.Add(10*time.Millisecond))
+	if !handled {
+		t.Fatal("handleRename should return true when pairing with a recent create")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paired) != 1 {
+		t.Fatalf("expected 1 paired event, got %d", len(paired))
+	}
+	if paired[0].From != srcDir {
+		t.Errorf("From = %q, want %q", paired[0].From, srcDir)
+	}
+	if paired[0].To != dstDir {
+		t.Errorf("To = %q, want %q", paired[0].To, dstDir)
+	}
+}
+
 func TestPairer_HandleCreateForFile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/homedrive/internal/watcher/rename_test.go
+++ b/homedrive/internal/watcher/rename_test.go
@@ -9,10 +9,6 @@ import (
 )
 
 func TestWatcher_DirRenameSmall(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("requires Linux inotify cookies")
-	}
-
 	w, root := newTestWatcher(t)
 	startWatcher(t, w)
 
@@ -69,11 +65,13 @@ func TestWatcher_DirRenameSmall(t *testing.T) {
 }
 
 func TestWatcher_DirRenameLarge(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("requires Linux inotify cookies")
-	}
-
-	w, root := newTestWatcher(t)
+	// On macOS/kqueue, processing 5k file events can delay the Rename event
+	// relative to its paired Create by more than the default 200ms window.
+	w, root := newTestWatcher(t, func(cfg *Config) {
+		if runtime.GOOS != "linux" {
+			cfg.DirRenamePairWindow = 1 * time.Second
+		}
+	})
 	startWatcher(t, w)
 
 	// Create a directory with 5k files.
@@ -125,18 +123,20 @@ func TestWatcher_DirRenameLarge(t *testing.T) {
 		}
 	}
 
-	if latency > 100*time.Millisecond {
-		t.Errorf("DirRename latency %v exceeds 100ms threshold", latency)
+	// Linux/inotify delivers paired rename events synchronously; kqueue on
+	// macOS may add latency from the directory-scan step in fsnotify.
+	latencyThreshold := 100 * time.Millisecond
+	if runtime.GOOS != "linux" {
+		latencyThreshold = 500 * time.Millisecond
+	}
+	if latency > latencyThreshold {
+		t.Errorf("DirRename latency %v exceeds %v threshold", latency, latencyThreshold)
 	}
 
 	t.Logf("DirRename latency for 5k-file directory: %v", latency)
 }
 
 func TestWatcher_DirRenameCrossMount(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("requires Linux inotify cookies")
-	}
-
 	// Cross-mount renames cannot be detected via cookies because the
 	// inode spaces are different. We simulate this by renaming to a
 	// path outside the watched tree (which produces only a Rename event
@@ -189,10 +189,6 @@ func TestWatcher_DirRenameCrossMount(t *testing.T) {
 }
 
 func TestWatcher_RapidDoubleRename(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("requires Linux inotify cookies")
-	}
-
 	w, root := newTestWatcher(t)
 	startWatcher(t, w)
 
@@ -233,10 +229,6 @@ func TestWatcher_RapidDoubleRename(t *testing.T) {
 }
 
 func TestWatcher_DirRenameWithExcludedFiles(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("requires Linux inotify cookies")
-	}
-
 	w, root := newTestWatcher(t, func(cfg *Config) {
 		cfg.Exclude = []string{"**/*.swp"}
 	})

--- a/homedrive/internal/watcher/rename_test.go
+++ b/homedrive/internal/watcher/rename_test.go
@@ -1,0 +1,287 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestWatcher_DirRenameSmall(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux inotify cookies")
+	}
+
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	// Create a directory with 10 files.
+	srcDir := filepath.Join(root, "src_dir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("failed to mkdir: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		path := filepath.Join(srcDir, "file_"+string(rune('a'+i))+".txt")
+		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+			t.Fatalf("failed to create file %d: %v", i, err)
+		}
+	}
+
+	// Wait for create events to settle.
+	collectEvents(t, w, 500*time.Millisecond)
+
+	// Rename the directory.
+	dstDir := filepath.Join(root, "dst_dir")
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("failed to rename directory: %v", err)
+	}
+
+	// Collect events. We expect exactly 1 DirRename event and no
+	// per-file events.
+	events := collectEvents(t, w, 1*time.Second)
+
+	dirRenames := 0
+	childEvents := 0
+	for _, ev := range events {
+		if ev.DirRename != nil {
+			dirRenames++
+			if ev.DirRename.From != srcDir {
+				t.Errorf("DirRename.From = %q, want %q", ev.DirRename.From, srcDir)
+			}
+			if ev.DirRename.To != dstDir {
+				t.Errorf("DirRename.To = %q, want %q", ev.DirRename.To, dstDir)
+			}
+		}
+		if ev.Event != nil {
+			childEvents++
+		}
+	}
+
+	if dirRenames != 1 {
+		t.Errorf("expected 1 DirRename event, got %d", dirRenames)
+	}
+	if childEvents > 0 {
+		t.Errorf("expected 0 child events (suppressed), got %d", childEvents)
+	}
+}
+
+func TestWatcher_DirRenameLarge(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux inotify cookies")
+	}
+
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	// Create a directory with 5k files.
+	srcDir := filepath.Join(root, "big_dir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("failed to mkdir: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	for i := 0; i < 5000; i++ {
+		name := filepath.Base(srcDir) + "_file_" + intToStr(i) + ".txt"
+		path := filepath.Join(srcDir, name)
+		if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+			t.Fatalf("failed to create file %d: %v", i, err)
+		}
+	}
+
+	// Wait for create events to settle.
+	collectEvents(t, w, 3*time.Second)
+
+	// Rename the directory and measure latency.
+	dstDir := filepath.Join(root, "big_dir_renamed")
+	start := time.Now()
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("failed to rename directory: %v", err)
+	}
+
+	// Wait for the DirRename event specifically.
+	var latency time.Duration
+	gotRename := false
+	deadline := time.After(2 * time.Second)
+	for !gotRename {
+		select {
+		case ev := <-w.Events():
+			if ev.DirRename != nil {
+				latency = time.Since(start)
+				gotRename = true
+				if ev.DirRename.From != srcDir {
+					t.Errorf("DirRename.From = %q, want %q",
+						ev.DirRename.From, srcDir)
+				}
+				if ev.DirRename.To != dstDir {
+					t.Errorf("DirRename.To = %q, want %q",
+						ev.DirRename.To, dstDir)
+				}
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for DirRename event for large dir")
+		}
+	}
+
+	if latency > 100*time.Millisecond {
+		t.Errorf("DirRename latency %v exceeds 100ms threshold", latency)
+	}
+
+	t.Logf("DirRename latency for 5k-file directory: %v", latency)
+}
+
+func TestWatcher_DirRenameCrossMount(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux inotify cookies")
+	}
+
+	// Cross-mount renames cannot be detected via cookies because the
+	// inode spaces are different. We simulate this by renaming to a
+	// path outside the watched tree (which produces only a Rename event
+	// without a matching Create).
+	w, root := newTestWatcher(t, func(cfg *Config) {
+		cfg.DirRenamePairWindow = 200 * time.Millisecond
+	})
+	startWatcher(t, w)
+
+	srcDir := filepath.Join(root, "cross_mount")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("failed to mkdir: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	// Write a file inside so the directory is not empty.
+	innerFile := filepath.Join(srcDir, "file.txt")
+	if err := os.WriteFile(innerFile, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	// Wait for events to settle.
+	collectEvents(t, w, 500*time.Millisecond)
+
+	// Rename to a directory outside the watched root, simulating
+	// a cross-mount move.
+	externalDir := t.TempDir()
+	dstDir := filepath.Join(externalDir, "cross_mount")
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("failed to rename directory: %v", err)
+	}
+
+	// Wait for the pair window to expire. We should get a fallback
+	// Rename event (not a DirRename).
+	events := collectEvents(t, w, 1*time.Second)
+
+	gotFallback := false
+	for _, ev := range events {
+		if ev.DirRename != nil {
+			t.Error("unexpected DirRename event for cross-mount move")
+		}
+		if ev.Event != nil && ev.Event.Op == OpRename {
+			gotFallback = true
+		}
+	}
+
+	if !gotFallback {
+		t.Error("expected fallback Rename event for cross-mount move")
+	}
+}
+
+func TestWatcher_RapidDoubleRename(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux inotify cookies")
+	}
+
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	// Create two directories.
+	dir1 := filepath.Join(root, "dir1")
+	dir2 := filepath.Join(root, "dir2")
+	if err := os.Mkdir(dir1, 0755); err != nil {
+		t.Fatalf("failed to mkdir dir1: %v", err)
+	}
+	if err := os.Mkdir(dir2, 0755); err != nil {
+		t.Fatalf("failed to mkdir dir2: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	collectEvents(t, w, 500*time.Millisecond)
+
+	// Rapid double rename.
+	dst1 := filepath.Join(root, "dir1_renamed")
+	dst2 := filepath.Join(root, "dir2_renamed")
+	if err := os.Rename(dir1, dst1); err != nil {
+		t.Fatalf("failed to rename dir1: %v", err)
+	}
+	if err := os.Rename(dir2, dst2); err != nil {
+		t.Fatalf("failed to rename dir2: %v", err)
+	}
+
+	events := collectEvents(t, w, 1*time.Second)
+
+	dirRenames := 0
+	for _, ev := range events {
+		if ev.DirRename != nil {
+			dirRenames++
+		}
+	}
+
+	if dirRenames != 2 {
+		t.Errorf("expected 2 DirRename events, got %d", dirRenames)
+	}
+}
+
+func TestWatcher_DirRenameWithExcludedFiles(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux inotify cookies")
+	}
+
+	w, root := newTestWatcher(t, func(cfg *Config) {
+		cfg.Exclude = []string{"**/*.swp"}
+	})
+	startWatcher(t, w)
+
+	// Create a directory containing only excluded files.
+	srcDir := filepath.Join(root, "excl_dir")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("failed to mkdir: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	swpPath := filepath.Join(srcDir, "file.swp")
+	if err := os.WriteFile(swpPath, []byte("swap"), 0644); err != nil {
+		t.Fatalf("failed to write excluded file: %v", err)
+	}
+
+	// Wait for events to settle.
+	collectEvents(t, w, 500*time.Millisecond)
+
+	// Rename the directory. The rename should still be paired even
+	// though all files inside are excluded.
+	dstDir := filepath.Join(root, "excl_dir_renamed")
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatalf("failed to rename directory: %v", err)
+	}
+
+	events := collectEvents(t, w, 1*time.Second)
+
+	dirRenames := 0
+	for _, ev := range events {
+		if ev.DirRename != nil {
+			dirRenames++
+			if ev.DirRename.From != srcDir {
+				t.Errorf("DirRename.From = %q, want %q",
+					ev.DirRename.From, srcDir)
+			}
+			if ev.DirRename.To != dstDir {
+				t.Errorf("DirRename.To = %q, want %q",
+					ev.DirRename.To, dstDir)
+			}
+		}
+	}
+
+	if dirRenames != 1 {
+		t.Errorf("expected 1 DirRename event, got %d", dirRenames)
+	}
+}

--- a/homedrive/internal/watcher/types.go
+++ b/homedrive/internal/watcher/types.go
@@ -1,0 +1,105 @@
+// Package watcher provides recursive fsnotify file watching with per-path
+// debouncing and directory rename pairing via inotify cookies.
+package watcher
+
+import (
+	"time"
+)
+
+// Op describes the type of file system operation observed.
+type Op int
+
+const (
+	// OpCreate indicates a new file or directory was created.
+	OpCreate Op = iota + 1
+	// OpWrite indicates a file was modified.
+	OpWrite
+	// OpRemove indicates a file or directory was removed.
+	OpRemove
+	// OpRename indicates a file or directory was renamed (unpaired).
+	OpRename
+	// OpDirRename indicates a paired directory rename was detected.
+	OpDirRename
+)
+
+// String returns the human-readable name of the operation.
+func (o Op) String() string {
+	switch o {
+	case OpCreate:
+		return "create"
+	case OpWrite:
+		return "write"
+	case OpRemove:
+		return "remove"
+	case OpRename:
+		return "rename"
+	case OpDirRename:
+		return "dir_rename"
+	default:
+		return "unknown"
+	}
+}
+
+// Event represents a single file system event after debouncing and filtering.
+type Event struct {
+	Path string
+	Op   Op
+	At   time.Time
+}
+
+// DirRename represents a paired directory rename detected via inotify cookies.
+// This collapses what would be thousands of child events into a single event,
+// enabling one Drive API call instead of thousands.
+type DirRename struct {
+	From string
+	To   string
+	At   time.Time
+}
+
+// WatchEvent is a union type sent on the watcher's output channel.
+// Exactly one of Event or DirRename is non-nil.
+type WatchEvent struct {
+	Event     *Event
+	DirRename *DirRename
+}
+
+// SyncRecord holds the sync state for a file, used by the inode/mtime guard
+// to suppress self-induced echoes from recent pulls. This is the minimal
+// interface the watcher needs from the store -- the full record lives in
+// internal/store/.
+type SyncRecord struct {
+	LocalMtime time.Time
+	Size       int64
+}
+
+// SyncStore is the interface the watcher uses to query last sync state.
+// The real implementation lives in internal/store/; tests provide a stub.
+type SyncStore interface {
+	// GetSyncRecord returns the last known sync record for a path.
+	// Returns nil if no record exists.
+	GetSyncRecord(path string) *SyncRecord
+}
+
+// Config holds watcher configuration.
+type Config struct {
+	// LocalRoot is the root directory to watch recursively.
+	LocalRoot string
+
+	// Debounce is the per-path debounce window. Default 2s.
+	Debounce time.Duration
+
+	// DirRenamePairWindow is the time window for matching rename cookies.
+	// Default 500ms.
+	DirRenamePairWindow time.Duration
+
+	// Exclude is a list of doublestar glob patterns to exclude.
+	Exclude []string
+}
+
+// DefaultConfig returns a Config with default values.
+func DefaultConfig() Config {
+	return Config{
+		Debounce:            2 * time.Second,
+		DirRenamePairWindow: 500 * time.Millisecond,
+	}
+}

--- a/homedrive/internal/watcher/types_test.go
+++ b/homedrive/internal/watcher/types_test.go
@@ -1,0 +1,26 @@
+package watcher
+
+import "testing"
+
+func TestOp_String(t *testing.T) {
+	tests := []struct {
+		name string
+		op   Op
+		want string
+	}{
+		{name: "Create", op: OpCreate, want: "create"},
+		{name: "Write", op: OpWrite, want: "write"},
+		{name: "Remove", op: OpRemove, want: "remove"},
+		{name: "Rename", op: OpRename, want: "rename"},
+		{name: "DirRename", op: OpDirRename, want: "dir_rename"},
+		{name: "Unknown", op: Op(99), want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.op.String(); got != tt.want {
+				t.Errorf("Op(%d).String() = %q, want %q", tt.op, got, tt.want)
+			}
+		})
+	}
+}

--- a/homedrive/internal/watcher/watcher.go
+++ b/homedrive/internal/watcher/watcher.go
@@ -1,3 +1,375 @@
 // Package watcher provides recursive fsnotify file watching with per-path
 // debouncing and directory rename pairing via inotify cookies.
 package watcher
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher recursively monitors a directory tree for file system changes.
+// It debounces rapid events per path, detects directory renames via
+// inotify cookie pairing, applies exclusion filters, and consults a
+// SyncStore to suppress self-induced echoes from recent pulls.
+type Watcher struct {
+	cfg    Config
+	log    *slog.Logger
+	store  SyncStore
+	filter *filter
+
+	fsw       *fsnotify.Watcher
+	debouncer *debouncer
+	pairer    *pairer
+
+	// events is the output channel for consumers.
+	events chan WatchEvent
+
+	mu      sync.Mutex
+	stopped bool
+	done    chan struct{}
+}
+
+// New creates a Watcher. The store may be nil if the inode/mtime guard
+// is not yet available (it will skip the guard check). Call Start() to
+// begin watching.
+func New(cfg Config, store SyncStore, log *slog.Logger) (*Watcher, error) {
+	if cfg.LocalRoot == "" {
+		return nil, fmt.Errorf("watcher: local_root must be set: %w", ErrInvalidConfig)
+	}
+	if cfg.Debounce == 0 {
+		cfg.Debounce = DefaultConfig().Debounce
+	}
+	if cfg.DirRenamePairWindow == 0 {
+		cfg.DirRenamePairWindow = DefaultConfig().DirRenamePairWindow
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("watcher: creating fsnotify watcher: %w", err)
+	}
+
+	w := &Watcher{
+		cfg:    cfg,
+		log:    log,
+		store:  store,
+		filter: newFilter(cfg.LocalRoot, cfg.Exclude),
+		fsw:    fsw,
+		events: make(chan WatchEvent, 1024),
+		done:   make(chan struct{}),
+	}
+
+	w.debouncer = newDebouncer(cfg.Debounce, w.emitEvent)
+
+	w.pairer = newPairer(
+		cfg.DirRenamePairWindow,
+		log,
+		w.onDirRenamePaired,
+		w.onDirRenameUnpaired,
+	)
+
+	return w, nil
+}
+
+// Events returns the read-only channel of watch events.
+func (w *Watcher) Events() <-chan WatchEvent {
+	return w.events
+}
+
+// Start performs the initial directory walk and begins the event loop.
+// It blocks until ctx is cancelled.
+func (w *Watcher) Start(ctx context.Context) error {
+	if err := w.initialWalk(); err != nil {
+		return fmt.Errorf("watcher: initial walk: %w", err)
+	}
+
+	w.log.Info("watcher started",
+		"root", w.cfg.LocalRoot,
+		"debounce", w.cfg.Debounce.String(),
+		"pair_window", w.cfg.DirRenamePairWindow.String(),
+		"exclude_patterns", len(w.cfg.Exclude),
+	)
+
+	return w.eventLoop(ctx)
+}
+
+// Stop shuts down the watcher. It is safe to call multiple times.
+func (w *Watcher) Stop() {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return
+	}
+	w.stopped = true
+	w.mu.Unlock()
+
+	w.debouncer.stop()
+	w.pairer.stop()
+	w.fsw.Close()
+	close(w.done)
+}
+
+// initialWalk walks the root directory tree and adds a watch on every
+// directory that is not excluded.
+func (w *Watcher) initialWalk() error {
+	return filepath.WalkDir(w.cfg.LocalRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			w.log.Warn("walk error", "path", path, "error", err)
+			return nil // Continue walking despite errors.
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if w.filter.excluded(path) {
+			return filepath.SkipDir
+		}
+		return w.addWatch(path)
+	})
+}
+
+// addWatch adds an fsnotify watch on a directory and registers it with
+// the pairer for rename detection.
+func (w *Watcher) addWatch(path string) error {
+	if err := w.fsw.Add(path); err != nil {
+		return fmt.Errorf("watcher: adding watch on %s: %w", path, err)
+	}
+	w.pairer.trackDir(path)
+	w.log.Debug("watch added", "path", path)
+	return nil
+}
+
+// removeWatch removes the fsnotify watch and unregisters from the pairer.
+func (w *Watcher) removeWatch(path string) {
+	w.fsw.Remove(path)
+	w.pairer.untrackDir(path)
+}
+
+// eventLoop reads fsnotify events and dispatches them through the
+// debouncer and rename pairer. It runs until ctx is cancelled or the
+// fsnotify watcher is closed.
+func (w *Watcher) eventLoop(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			w.Stop()
+			return ctx.Err()
+
+		case <-w.done:
+			return nil
+
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return nil
+			}
+			w.handleFSEvent(ev)
+
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return nil
+			}
+			w.log.Error("fsnotify error", "error", err)
+		}
+	}
+}
+
+// handleFSEvent processes a single fsnotify event through the filter,
+// pairer, mtime guard, and debouncer.
+func (w *Watcher) handleFSEvent(ev fsnotify.Event) {
+	path := ev.Name
+
+	// Skip excluded paths.
+	if w.filter.excluded(path) {
+		return
+	}
+
+	// Check if this event is suppressed by a recent directory rename.
+	if w.pairer.isSuppressed(path) {
+		return
+	}
+
+	now := time.Now()
+
+	// Handle rename events: buffer directory renames for pairing.
+	if ev.Has(fsnotify.Rename) {
+		if w.pairer.handleRename(path, now) {
+			return
+		}
+		// File rename (not a directory we were watching) falls through
+		// to the debouncer as a regular rename event.
+		w.debouncePath(path, OpRename, now)
+		return
+	}
+
+	// Handle create events: check if they pair with a buffered rename.
+	if ev.Has(fsnotify.Create) {
+		if w.pairer.handleCreate(path, now) {
+			return
+		}
+
+		// Not a paired rename. If it is a new directory, add a watch.
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			if addErr := w.addWatch(path); addErr != nil {
+				w.log.Warn("failed to add watch on new directory",
+					"path", path,
+					"error", addErr,
+				)
+			}
+			// Walk the new directory to catch any files already inside.
+			w.walkNewDir(path)
+		}
+
+		w.debouncePath(path, OpCreate, now)
+		return
+	}
+
+	// Handle write events.
+	if ev.Has(fsnotify.Write) {
+		w.debouncePath(path, OpWrite, now)
+		return
+	}
+
+	// Handle remove events.
+	if ev.Has(fsnotify.Remove) {
+		// The kernel automatically removes the inotify watch when the
+		// directory is deleted; just clean up our tracking.
+		w.pairer.untrackDir(path)
+		w.debouncePath(path, OpRemove, now)
+		return
+	}
+}
+
+// debouncePath checks the mtime guard and feeds the event to the debouncer.
+func (w *Watcher) debouncePath(path string, op Op, at time.Time) {
+	// Inode/mtime guard: suppress self-induced echoes.
+	if w.store != nil && (op == OpWrite || op == OpCreate) {
+		if w.isSelfInduced(path) {
+			w.log.Debug("suppressed self-induced event",
+				"path", path,
+				"op", op.String(),
+			)
+			return
+		}
+	}
+
+	w.debouncer.add(Event{Path: path, Op: op, At: at})
+}
+
+// isSelfInduced checks if a file event matches the last recorded sync
+// state within a 1-second tolerance, indicating it was caused by a
+// recent pull rather than a user modification.
+func (w *Watcher) isSelfInduced(path string) bool {
+	rec := w.store.GetSyncRecord(path)
+	if rec == nil {
+		return false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	mtime := info.ModTime()
+	diff := mtime.Sub(rec.LocalMtime)
+	if diff < 0 {
+		diff = -diff
+	}
+
+	return diff <= time.Second && info.Size() == rec.Size
+}
+
+// walkNewDir adds watches to all subdirectories of a newly created directory.
+func (w *Watcher) walkNewDir(root string) {
+	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() || path == root {
+			return nil
+		}
+		if w.filter.excluded(path) {
+			return filepath.SkipDir
+		}
+		if addErr := w.addWatch(path); addErr != nil {
+			w.log.Warn("failed to add watch during new dir walk",
+				"path", path,
+				"error", addErr,
+			)
+		}
+		return nil
+	})
+}
+
+// emitEvent sends a debounced event to the output channel.
+func (w *Watcher) emitEvent(ev Event) {
+	select {
+	case w.events <- WatchEvent{Event: &ev}:
+	default:
+		w.log.Warn("event channel full, dropping event",
+			"path", ev.Path,
+			"op", ev.Op.String(),
+		)
+	}
+}
+
+// onDirRenamePaired handles a successful directory rename pairing.
+// It re-watches the new subtree and suppresses child events.
+func (w *Watcher) onDirRenamePaired(dr DirRename) {
+	// Remove watches under the old path.
+	w.removeSubtreeWatches(dr.From)
+
+	// Add watches under the new path.
+	if err := w.addWatch(dr.To); err != nil {
+		w.log.Warn("failed to re-watch renamed directory",
+			"path", dr.To,
+			"error", err,
+		)
+	}
+	w.walkNewDir(dr.To)
+
+	// Suppress any debounced events under both old and new paths.
+	w.debouncer.suppressPrefix(dr.From + string(filepath.Separator))
+	w.debouncer.suppressPrefix(dr.To + string(filepath.Separator))
+
+	// Emit the paired rename event.
+	select {
+	case w.events <- WatchEvent{DirRename: &dr}:
+	default:
+		w.log.Warn("event channel full, dropping dir_rename",
+			"from", dr.From,
+			"to", dr.To,
+		)
+	}
+}
+
+// onDirRenameUnpaired handles an expired rename (no matching Create).
+// It falls back to standard delete handling.
+func (w *Watcher) onDirRenameUnpaired(ev Event) {
+	w.emitEvent(ev)
+}
+
+// removeSubtreeWatches removes watches on the given directory and all
+// its known subdirectories.
+func (w *Watcher) removeSubtreeWatches(root string) {
+	prefix := root + string(filepath.Separator)
+	w.removeWatch(root)
+
+	// Walk the pairer's tracked dirs to find children.
+	w.pairer.mu.Lock()
+	var toRemove []string
+	for dir := range w.pairer.watchedDirs {
+		if len(dir) > len(prefix) && dir[:len(prefix)] == prefix {
+			toRemove = append(toRemove, dir)
+		}
+	}
+	w.pairer.mu.Unlock()
+
+	for _, dir := range toRemove {
+		w.removeWatch(dir)
+	}
+}

--- a/homedrive/internal/watcher/watcher.go
+++ b/homedrive/internal/watcher/watcher.go
@@ -111,7 +111,9 @@ func (w *Watcher) Stop() {
 
 	w.debouncer.stop()
 	w.pairer.stop()
-	w.fsw.Close()
+	if err := w.fsw.Close(); err != nil {
+		w.log.Warn("fsnotify close error", "error", err)
+	}
 	close(w.done)
 }
 
@@ -146,7 +148,7 @@ func (w *Watcher) addWatch(path string) error {
 
 // removeWatch removes the fsnotify watch and unregisters from the pairer.
 func (w *Watcher) removeWatch(path string) {
-	w.fsw.Remove(path)
+	_ = w.fsw.Remove(path) // best-effort; path may already be unwatched after rename
 	w.pairer.untrackDir(path)
 }
 
@@ -285,7 +287,7 @@ func (w *Watcher) isSelfInduced(path string) bool {
 
 // walkNewDir adds watches to all subdirectories of a newly created directory.
 func (w *Watcher) walkNewDir(root string) {
-	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}

--- a/homedrive/internal/watcher/watcher.go
+++ b/homedrive/internal/watcher/watcher.go
@@ -334,7 +334,10 @@ func (w *Watcher) onDirRenamePaired(dr DirRename) {
 	}
 	w.walkNewDir(dr.To)
 
-	// Suppress any debounced events under both old and new paths.
+	// Suppress any debounced events under both old and new paths, and the
+	// new directory's own Create event (present in the debouncer on macOS/kqueue
+	// when Create(dst) arrived before Rename(src) was paired).
+	w.debouncer.suppress(dr.To)
 	w.debouncer.suppressPrefix(dr.From + string(filepath.Separator))
 	w.debouncer.suppressPrefix(dr.To + string(filepath.Separator))
 

--- a/homedrive/internal/watcher/watcher_test.go
+++ b/homedrive/internal/watcher/watcher_test.go
@@ -1,0 +1,226 @@
+package watcher
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcher_CreateFile(t *testing.T) {
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	path := filepath.Join(root, "hello.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	ev, ok := waitForEvent(t, w, 500*time.Millisecond)
+	if !ok {
+		t.Fatal("timed out waiting for create event")
+	}
+	if ev.Event == nil {
+		t.Fatal("expected Event, got DirRename")
+	}
+	if ev.Event.Path != path {
+		t.Errorf("expected path %s, got %s", path, ev.Event.Path)
+	}
+	if ev.Event.Op != OpCreate {
+		t.Errorf("expected OpCreate, got %v", ev.Event.Op)
+	}
+}
+
+func TestWatcher_WriteDebounced(t *testing.T) {
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	// Create a file first.
+	path := filepath.Join(root, "burst.txt")
+	if err := os.WriteFile(path, []byte("v0"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Wait for the create event to clear.
+	collectEvents(t, w, 300*time.Millisecond)
+
+	// Write 10 times rapidly.
+	for i := 0; i < 10; i++ {
+		if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+			t.Fatalf("write %d failed: %v", i, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Collect events. The debouncer (100ms) should coalesce to 1 event.
+	events := collectEvents(t, w, 500*time.Millisecond)
+
+	writeCount := 0
+	for _, ev := range events {
+		if ev.Event != nil && ev.Event.Path == path {
+			writeCount++
+		}
+	}
+
+	if writeCount != 1 {
+		t.Errorf("expected 1 debounced write event, got %d (total events: %d)",
+			writeCount, len(events))
+	}
+}
+
+func TestWatcher_DynamicAddWatch(t *testing.T) {
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	// Create a new subdirectory.
+	subdir := filepath.Join(root, "newdir")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatalf("failed to mkdir: %v", err)
+	}
+
+	// Wait for the directory create event and watch setup.
+	time.Sleep(200 * time.Millisecond)
+	collectEvents(t, w, 300*time.Millisecond)
+
+	// Create a file inside the new directory.
+	filePath := filepath.Join(subdir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write file in new dir: %v", err)
+	}
+
+	ev, ok := waitForEvent(t, w, 500*time.Millisecond)
+	if !ok {
+		t.Fatal("timed out waiting for event in dynamically watched dir")
+	}
+	if ev.Event == nil {
+		t.Fatal("expected Event, got DirRename")
+	}
+	if ev.Event.Path != filePath {
+		t.Errorf("expected path %s, got %s", filePath, ev.Event.Path)
+	}
+}
+
+func TestWatcher_ExcludeFilter(t *testing.T) {
+	w, root := newTestWatcher(t, func(cfg *Config) {
+		cfg.Exclude = []string{"**/*.swp", "**/.git/**"}
+	})
+	startWatcher(t, w)
+
+	// Create an excluded file.
+	swpPath := filepath.Join(root, "file.swp")
+	if err := os.WriteFile(swpPath, []byte("swap"), 0644); err != nil {
+		t.Fatalf("failed to write swp file: %v", err)
+	}
+
+	// Create a non-excluded file.
+	txtPath := filepath.Join(root, "file.txt")
+	if err := os.WriteFile(txtPath, []byte("text"), 0644); err != nil {
+		t.Fatalf("failed to write txt file: %v", err)
+	}
+
+	events := collectEvents(t, w, 500*time.Millisecond)
+
+	for _, ev := range events {
+		if ev.Event != nil && ev.Event.Path == swpPath {
+			t.Errorf("received event for excluded path %s", swpPath)
+		}
+	}
+
+	gotTxt := false
+	for _, ev := range events {
+		if ev.Event != nil && ev.Event.Path == txtPath {
+			gotTxt = true
+		}
+	}
+	if !gotTxt {
+		t.Error("expected event for non-excluded file.txt")
+	}
+}
+
+func TestWatcher_MtimeGuard(t *testing.T) {
+	root := t.TempDir()
+
+	filePath := filepath.Join(root, "synced.txt")
+	if err := os.WriteFile(filePath, []byte("synced content"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatalf("failed to stat file: %v", err)
+	}
+
+	store := &stubStore{
+		records: map[string]*SyncRecord{
+			filePath: {
+				LocalMtime: info.ModTime(),
+				Size:       info.Size(),
+			},
+		},
+	}
+
+	cfg := Config{
+		LocalRoot:           root,
+		Debounce:            100 * time.Millisecond,
+		DirRenamePairWindow: 200 * time.Millisecond,
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	w, err := New(cfg, store, log)
+	if err != nil {
+		t.Fatalf("failed to create watcher: %v", err)
+	}
+
+	startWatcher(t, w)
+
+	// Rewrite with same content (simulating a pull echo).
+	if err := os.WriteFile(filePath, []byte("synced content"), 0644); err != nil {
+		t.Fatalf("failed to rewrite file: %v", err)
+	}
+
+	events := collectEvents(t, w, 500*time.Millisecond)
+
+	for _, ev := range events {
+		if ev.Event != nil && ev.Event.Path == filePath && ev.Event.Op == OpWrite {
+			t.Error("expected mtime guard to suppress self-induced write")
+		}
+	}
+}
+
+func TestWatcher_InvalidConfig(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	_, err := New(Config{}, nil, log)
+	if err == nil {
+		t.Fatal("expected error for empty config")
+	}
+}
+
+func TestWatcher_RemoveFile(t *testing.T) {
+	w, root := newTestWatcher(t)
+	startWatcher(t, w)
+
+	path := filepath.Join(root, "doomed.txt")
+	if err := os.WriteFile(path, []byte("goodbye"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	collectEvents(t, w, 300*time.Millisecond)
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("failed to remove file: %v", err)
+	}
+
+	ev, ok := waitForEvent(t, w, 500*time.Millisecond)
+	if !ok {
+		t.Fatal("timed out waiting for remove event")
+	}
+	if ev.Event == nil {
+		t.Fatal("expected Event, got DirRename")
+	}
+	if ev.Event.Op != OpRemove {
+		t.Errorf("expected OpRemove, got %v", ev.Event.Op)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the fsnotify-based recursive watcher with debouncing and directory rename pairing (Phase 1)
- Fixes `TestWatcher_DirRenameSmall`: `isSuppressed` now also matches the renamed directory path itself, catching the late `IN_MOVE_SELF` `Rename` event that fires after the pair completes and the path is untracked
- Updates `homedrive-watcher-rename` skill with the `IN_MOVE_SELF` edge case and corrects "keyed by cookie" → "keyed by path"

## Root cause of CI failure

On Linux, renaming a watched directory fires two rename events:
1. `IN_MOVED_FROM` on the parent → `Rename(srcDir)` — paired ✓  
2. `IN_MOVE_SELF` on `srcDir`'s own wd → `Rename(srcDir)` — arrives **after** pairing

After pairing, `srcDir` is untracked and `suppressedPrefixes` only holds `srcDir + "/"`. `isSuppressed("srcDir")` returned false, letting the event leak. Fix: `path == dirPath || strings.HasPrefix(path, prefix)`.

## Test plan

- [ ] `TestWatcher_DirRenameSmall` passes (was failing with "expected 0 child events, got 1")
- [ ] All other watcher tests continue to pass
- [ ] CI green on amd64 and arm64