### PR TITLE
Phase 10: Quota-aware push throttling

### DIFF
--- a/homedrive/internal/quota/evaluate_test.go
+++ b/homedrive/internal/quota/evaluate_test.go
@@ -1,0 +1,169 @@
+package quota
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestMonitor_StateTransitions(t *testing.T) {
+	// Table-driven test of the full state machine with hysteresis.
+	tests := []struct {
+		name          string
+		prevState     State
+		usedPct       float64
+		wantState     State
+		wantPaused    bool
+		wantEventType string // "" means no event expected
+	}{
+		{
+			name:       "Normal_50pct_stays_normal",
+			prevState:  StateNormal,
+			usedPct:    50,
+			wantState:  StateNormal,
+			wantPaused: false,
+		},
+		{
+			name:          "Normal_91pct_transitions_to_warned",
+			prevState:     StateNormal,
+			usedPct:       91,
+			wantState:     StateWarned,
+			wantPaused:    false,
+			wantEventType: "quota.warning",
+		},
+		{
+			name:          "Normal_99pct_transitions_to_blocked",
+			prevState:     StateNormal,
+			usedPct:       99,
+			wantState:     StateBlocked,
+			wantPaused:    true,
+			wantEventType: "quota.exhausted",
+		},
+		{
+			name:       "Warned_91pct_stays_warned",
+			prevState:  StateWarned,
+			usedPct:    91,
+			wantState:  StateWarned,
+			wantPaused: false,
+		},
+		{
+			name:          "Warned_99pct_transitions_to_blocked",
+			prevState:     StateWarned,
+			usedPct:       99,
+			wantState:     StateBlocked,
+			wantPaused:    true,
+			wantEventType: "quota.exhausted",
+		},
+		{
+			name:       "Warned_50pct_transitions_to_normal",
+			prevState:  StateWarned,
+			usedPct:    50,
+			wantState:  StateNormal,
+			wantPaused: false,
+		},
+		{
+			name:       "Blocked_99pct_stays_blocked",
+			prevState:  StateBlocked,
+			usedPct:    99,
+			wantState:  StateBlocked,
+			wantPaused: true,
+		},
+		{
+			name:       "Blocked_95pct_stays_blocked_hysteresis",
+			prevState:  StateBlocked,
+			usedPct:    95,
+			wantState:  StateBlocked,
+			wantPaused: true,
+		},
+		{
+			name:       "Blocked_94pct_stays_blocked_at_threshold",
+			prevState:  StateBlocked,
+			usedPct:    94,
+			wantState:  StateBlocked,
+			wantPaused: true,
+		},
+		{
+			name:          "Blocked_93pct_resumes_to_warned",
+			prevState:     StateBlocked,
+			usedPct:       93,
+			wantState:     StateWarned,
+			wantPaused:    false,
+			wantEventType: "quota.warning",
+		},
+		{
+			name:       "Blocked_50pct_resumes_to_normal",
+			prevState:  StateBlocked,
+			usedPct:    50,
+			wantState:  StateNormal,
+			wantPaused: false,
+		},
+		{
+			name:       "Blocked_89pct_resumes_to_normal",
+			prevState:  StateBlocked,
+			usedPct:    89,
+			wantState:  StateNormal,
+			wantPaused: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			used := int64(tt.usedPct)
+			remote := &mockRemoteFS{quota: QuotaInfo{Used: used, Total: 100}}
+			pub := &mockPublisher{}
+			push := &mockPushController{}
+			cfg := DefaultConfig()
+			log := slog.Default()
+			mon := NewMonitor(remote, pub, push, cfg, log)
+
+			// Set the initial state to simulate prior history.
+			mon.mu.Lock()
+			mon.state = tt.prevState
+			if tt.prevState == StateBlocked {
+				push.PausePush() // simulate prior pause
+			}
+			mon.mu.Unlock()
+
+			// Clear events from setup.
+			pub.Reset()
+			initialPauseCt := push.PauseCount()
+			initialResumeCt := push.ResumeCount()
+
+			mon.Poll(context.Background())
+
+			snap := mon.State()
+			if snap.State != tt.wantState {
+				t.Errorf("state: got %q, want %q", snap.State, tt.wantState)
+			}
+
+			if push.IsPaused() != tt.wantPaused {
+				t.Errorf("paused: got %v, want %v", push.IsPaused(), tt.wantPaused)
+			}
+
+			events := pub.Events()
+			if tt.wantEventType == "" {
+				if len(events) != 0 {
+					t.Errorf("expected no events, got %d: %+v", len(events), events)
+				}
+			} else {
+				if len(events) != 1 {
+					t.Fatalf("expected 1 event, got %d", len(events))
+				}
+				if events[0].Payload["type"] != tt.wantEventType {
+					t.Errorf("event type: got %v, want %s",
+						events[0].Payload["type"], tt.wantEventType)
+				}
+			}
+
+			// No state change means no new pause/resume calls.
+			if tt.prevState == tt.wantState {
+				if push.PauseCount() != initialPauseCt {
+					t.Error("PausePush called without a state transition")
+				}
+				if push.ResumeCount() != initialResumeCt {
+					t.Error("ResumePush called without a state transition")
+				}
+			}
+		})
+	}
+}

--- a/homedrive/internal/quota/mock_test.go
+++ b/homedrive/internal/quota/mock_test.go
@@ -1,0 +1,137 @@
+package quota
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+// --- test doubles ---
+
+// mockRemoteFS implements RemoteFS for testing.
+type mockRemoteFS struct {
+	mu    sync.Mutex
+	quota QuotaInfo
+	err   error
+}
+
+func (m *mockRemoteFS) Quota(_ context.Context) (QuotaInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.quota, m.err
+}
+
+func (m *mockRemoteFS) SetQuota(used, total int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.quota = QuotaInfo{Used: used, Total: total}
+}
+
+func (m *mockRemoteFS) SetError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+// mockPublisher implements Publisher for testing.
+type mockPublisher struct {
+	mu     sync.Mutex
+	events []publishedEvent
+}
+
+type publishedEvent struct {
+	Topic   string
+	Payload map[string]any
+}
+
+func (p *mockPublisher) PublishJSON(topic string, payload any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Marshal and unmarshal to normalize the payload to map[string]any.
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("mock publish marshal: %w", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return fmt.Errorf("mock publish unmarshal: %w", err)
+	}
+	p.events = append(p.events, publishedEvent{Topic: topic, Payload: m})
+	return nil
+}
+
+func (p *mockPublisher) Topic(parts ...string) string {
+	result := "homedrive/testhost/testuser"
+	for _, part := range parts {
+		result += "/" + part
+	}
+	return result
+}
+
+func (p *mockPublisher) Events() []publishedEvent {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := make([]publishedEvent, len(p.events))
+	copy(cp, p.events)
+	return cp
+}
+
+func (p *mockPublisher) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = nil
+}
+
+// mockPushController implements PushController for testing.
+type mockPushController struct {
+	mu       sync.Mutex
+	paused   bool
+	pauseCt  int
+	resumeCt int
+}
+
+func (c *mockPushController) PausePush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paused = true
+	c.pauseCt++
+}
+
+func (c *mockPushController) ResumePush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.paused = false
+	c.resumeCt++
+}
+
+func (c *mockPushController) IsPaused() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.paused
+}
+
+func (c *mockPushController) PauseCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pauseCt
+}
+
+func (c *mockPushController) ResumeCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.resumeCt
+}
+
+// --- helpers ---
+
+func newTestMonitor(t *testing.T, remote *mockRemoteFS, pub *mockPublisher, push *mockPushController, dryRun bool) *Monitor {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.DryRun = dryRun
+	log := slog.Default()
+	return NewMonitor(remote, pub, push, cfg, log)
+}

--- a/homedrive/internal/quota/mock_test.go
+++ b/homedrive/internal/quota/mock_test.go
@@ -126,6 +126,21 @@ func (c *mockPushController) ResumeCount() int {
 	return c.resumeCt
 }
 
+// notifyingRemoteFS wraps a mockRemoteFS and sends to ch on every Quota call.
+type notifyingRemoteFS struct {
+	inner *mockRemoteFS
+	ch    chan struct{}
+}
+
+func (n *notifyingRemoteFS) Quota(ctx context.Context) (QuotaInfo, error) {
+	qi, err := n.inner.Quota(ctx)
+	select {
+	case n.ch <- struct{}{}:
+	default:
+	}
+	return qi, err
+}
+
 // --- helpers ---
 
 func newTestMonitor(t *testing.T, remote *mockRemoteFS, pub *mockPublisher, push *mockPushController, dryRun bool) *Monitor {

--- a/homedrive/internal/quota/quota.go
+++ b/homedrive/internal/quota/quota.go
@@ -1,0 +1,290 @@
+// Package quota implements quota-aware push throttling for homedrive.
+//
+// It periodically polls the remote filesystem's quota and transitions
+// through states (normal -> warned -> blocked) based on configurable
+// thresholds with hysteresis to prevent flapping. Push workers are
+// paused when quota is exhausted; pull continues unaffected.
+package quota
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// QuotaInfo holds used/total byte counts returned by the remote filesystem.
+type QuotaInfo struct {
+	Used  int64
+	Total int64
+}
+
+// UsedPercent returns the quota usage as a percentage (0-100).
+// Returns 0 if Total is zero or negative (avoids division by zero).
+func (q QuotaInfo) UsedPercent() float64 {
+	if q.Total <= 0 {
+		return 0
+	}
+	return float64(q.Used) / float64(q.Total) * 100
+}
+
+// RemoteFS is the subset of the rclone client interface needed by the
+// quota monitor. Defined locally so this package compiles independently
+// of internal/rcloneclient.
+type RemoteFS interface {
+	Quota(ctx context.Context) (QuotaInfo, error)
+}
+
+// Publisher is the subset of the MQTT publisher interface needed to emit
+// quota warning and exhaustion events. Defined locally so this package
+// compiles independently of internal/mqtt.
+type Publisher interface {
+	PublishJSON(topic string, payload any) error
+	Topic(parts ...string) string
+}
+
+// PushController allows the quota monitor to pause and resume push
+// workers without depending on the syncer package directly.
+type PushController interface {
+	PausePush()
+	ResumePush()
+}
+
+// State represents the current quota state of the monitor.
+type State string
+
+const (
+	// StateNormal means quota usage is below the warning threshold.
+	StateNormal State = "normal"
+	// StateWarned means quota usage is above warn_pct but below stop_push_pct.
+	StateWarned State = "warned"
+	// StateBlocked means quota usage is at or above stop_push_pct; pushes are paused.
+	StateBlocked State = "quota_blocked"
+)
+
+// Config holds the quota monitor's tunable parameters.
+type Config struct {
+	// PollInterval is how often to poll Quota(). Default 5 minutes.
+	PollInterval time.Duration
+	// WarnPct is the usage percentage above which a warning event is emitted.
+	// Default 90.
+	WarnPct float64
+	// StopPushPct is the usage percentage at or above which push workers are
+	// paused. Default 99.
+	StopPushPct float64
+	// HysteresisPct is the percentage below StopPushPct at which pushes
+	// resume after being blocked. Default is StopPushPct - 5 (i.e. 94).
+	HysteresisPct float64
+	// DryRun when true polls quota and logs transitions but does not
+	// actually pause or resume push workers.
+	DryRun bool
+}
+
+// DefaultConfig returns the default quota configuration per PLAN.md.
+func DefaultConfig() Config {
+	return Config{
+		PollInterval:  5 * time.Minute,
+		WarnPct:       90,
+		StopPushPct:   99,
+		HysteresisPct: 94,
+		DryRun:        false,
+	}
+}
+
+// Snapshot is a point-in-time view of the quota monitor's state, exposed
+// to the /status HTTP endpoint.
+type Snapshot struct {
+	State       State     `json:"state"`
+	UsedBytes   int64     `json:"used_bytes"`
+	TotalBytes  int64     `json:"total_bytes"`
+	UsedPercent float64   `json:"used_percent"`
+	LastPoll    time.Time `json:"last_poll"`
+	LastError   string    `json:"last_error,omitempty"`
+}
+
+// Monitor polls the remote filesystem quota and manages push throttling.
+type Monitor struct {
+	remote RemoteFS
+	pub    Publisher
+	push   PushController
+	cfg    Config
+	log    *slog.Logger
+
+	mu        sync.RWMutex
+	state     State
+	lastQuota QuotaInfo
+	lastPoll  time.Time
+	lastErr   error
+}
+
+// NewMonitor creates a quota monitor. The publisher and push controller
+// may be nil if the features are not wired yet (events and pause/resume
+// are skipped gracefully).
+func NewMonitor(remote RemoteFS, pub Publisher, push PushController, cfg Config, log *slog.Logger) *Monitor {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Monitor{
+		remote: remote,
+		pub:    pub,
+		push:   push,
+		cfg:    cfg,
+		log:    log,
+		state:  StateNormal,
+	}
+}
+
+// State returns the current quota state snapshot.
+func (m *Monitor) State() Snapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	errStr := ""
+	if m.lastErr != nil {
+		errStr = m.lastErr.Error()
+	}
+	return Snapshot{
+		State:       m.state,
+		UsedBytes:   m.lastQuota.Used,
+		TotalBytes:  m.lastQuota.Total,
+		UsedPercent: m.lastQuota.UsedPercent(),
+		LastPoll:    m.lastPoll,
+		LastError:   errStr,
+	}
+}
+
+// Run starts the polling loop. It blocks until the context is cancelled.
+func (m *Monitor) Run(ctx context.Context) error {
+	// Poll immediately on start, then on the configured interval.
+	m.poll(ctx)
+
+	ticker := time.NewTicker(m.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			m.poll(ctx)
+		}
+	}
+}
+
+// Poll performs a single quota check and state transition. Exported for
+// testing; production code should use Run.
+func (m *Monitor) Poll(ctx context.Context) {
+	m.poll(ctx)
+}
+
+func (m *Monitor) poll(ctx context.Context) {
+	qi, err := m.remote.Quota(ctx)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.lastPoll = time.Now()
+	if err != nil {
+		m.lastErr = fmt.Errorf("quota poll failed: %w", err)
+		m.log.Error("quota poll failed", "error", err)
+		return
+	}
+	m.lastErr = nil
+	m.lastQuota = qi
+
+	pct := qi.UsedPercent()
+	prev := m.state
+	next := m.evaluate(pct, prev)
+
+	if next != prev {
+		m.transition(prev, next, pct)
+	}
+}
+
+// evaluate determines the next state given the current usage percentage
+// and previous state. It implements the hysteresis logic: once blocked,
+// the monitor stays blocked until usage drops below HysteresisPct.
+func (m *Monitor) evaluate(pct float64, prev State) State {
+	switch {
+	case pct >= m.cfg.StopPushPct:
+		return StateBlocked
+	case prev == StateBlocked && pct >= m.cfg.HysteresisPct:
+		// Still above hysteresis threshold; stay blocked.
+		return StateBlocked
+	case pct >= m.cfg.WarnPct:
+		return StateWarned
+	default:
+		return StateNormal
+	}
+}
+
+func (m *Monitor) transition(prev, next State, pct float64) {
+	m.state = next
+
+	m.log.Info("quota state transition",
+		"op", "quota_transition",
+		"from", string(prev),
+		"to", string(next),
+		"used_percent", pct,
+		"dry_run", m.cfg.DryRun,
+	)
+
+	switch next {
+	case StateWarned:
+		m.emitEvent("quota.warning", pct)
+		// If we were blocked and dropped to warned, resume pushes.
+		if prev == StateBlocked {
+			m.resumePush()
+		}
+	case StateBlocked:
+		m.emitEvent("quota.exhausted", pct)
+		m.pausePush()
+	case StateNormal:
+		// If transitioning from blocked or warned back to normal, resume.
+		if prev == StateBlocked {
+			m.resumePush()
+		}
+	}
+}
+
+func (m *Monitor) pausePush() {
+	if m.cfg.DryRun {
+		m.log.Info("dry-run: would pause push workers",
+			"op", "quota_pause_push",
+		)
+		return
+	}
+	if m.push != nil {
+		m.push.PausePush()
+	}
+}
+
+func (m *Monitor) resumePush() {
+	if m.cfg.DryRun {
+		m.log.Info("dry-run: would resume push workers",
+			"op", "quota_resume_push",
+		)
+		return
+	}
+	if m.push != nil {
+		m.push.ResumePush()
+	}
+}
+
+func (m *Monitor) emitEvent(eventType string, pct float64) {
+	if m.pub == nil {
+		return
+	}
+	topic := m.pub.Topic("events", eventType)
+	payload := map[string]any{
+		"ts":           time.Now().UTC().Format(time.RFC3339),
+		"type":         eventType,
+		"used_percent": pct,
+	}
+	if err := m.pub.PublishJSON(topic, payload); err != nil {
+		m.log.Error("failed to publish quota event",
+			"error", err,
+			"event_type", eventType,
+		)
+	}
+}

--- a/homedrive/internal/quota/quota.go
+++ b/homedrive/internal/quota/quota.go
@@ -181,23 +181,28 @@ func (m *Monitor) poll(ctx context.Context) {
 	qi, err := m.remote.Quota(ctx)
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.lastPoll = time.Now()
 	if err != nil {
 		m.lastErr = fmt.Errorf("quota poll failed: %w", err)
+		m.mu.Unlock()
+		// State is not changed on poll errors — if push was already paused,
+		// the monitor stays blocked. Resuming without knowing quota level
+		// would be unsafe.
 		m.log.Error("quota poll failed", "error", err)
 		return
 	}
 	m.lastErr = nil
 	m.lastQuota = qi
-
 	pct := qi.UsedPercent()
 	prev := m.state
 	next := m.evaluate(pct, prev)
+	if next != prev {
+		m.state = next
+	}
+	m.mu.Unlock()
 
 	if next != prev {
-		m.transition(prev, next, pct)
+		m.applyTransition(prev, next, pct)
 	}
 }
 
@@ -218,9 +223,7 @@ func (m *Monitor) evaluate(pct float64, prev State) State {
 	}
 }
 
-func (m *Monitor) transition(prev, next State, pct float64) {
-	m.state = next
-
+func (m *Monitor) applyTransition(prev, next State, pct float64) {
 	m.log.Info("quota state transition",
 		"op", "quota_transition",
 		"from", string(prev),

--- a/homedrive/internal/quota/quota.go
+++ b/homedrive/internal/quota/quota.go
@@ -243,7 +243,7 @@ func (m *Monitor) applyTransition(prev, next State, pct float64) {
 		m.emitEvent("quota.exhausted", pct)
 		m.pausePush()
 	case StateNormal:
-		// If transitioning from blocked or warned back to normal, resume.
+		// Warned state does not pause push, so only resume from blocked.
 		if prev == StateBlocked {
 			m.resumePush()
 		}

--- a/homedrive/internal/quota/quota_test.go
+++ b/homedrive/internal/quota/quota_test.go
@@ -1,0 +1,356 @@
+package quota
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestMonitor_NormalQuota(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 50, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateNormal {
+		t.Errorf("expected state %q, got %q", StateNormal, snap.State)
+	}
+	if snap.UsedPercent != 50 {
+		t.Errorf("expected used_percent 50, got %v", snap.UsedPercent)
+	}
+	if len(pub.Events()) != 0 {
+		t.Errorf("expected no events, got %d", len(pub.Events()))
+	}
+	if push.IsPaused() {
+		t.Error("push should not be paused at 50% quota")
+	}
+}
+
+func TestMonitor_WarningEmitted(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 91, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateWarned {
+		t.Errorf("expected state %q, got %q", StateWarned, snap.State)
+	}
+	events := pub.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Payload["type"] != "quota.warning" {
+		t.Errorf("expected event type quota.warning, got %v", events[0].Payload["type"])
+	}
+	if push.IsPaused() {
+		t.Error("push should not be paused at 91% (warned, not blocked)")
+	}
+}
+
+func TestMonitor_QuotaExhausted(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateBlocked {
+		t.Errorf("expected state %q, got %q", StateBlocked, snap.State)
+	}
+	events := pub.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Payload["type"] != "quota.exhausted" {
+		t.Errorf("expected event type quota.exhausted, got %v", events[0].Payload["type"])
+	}
+	if !push.IsPaused() {
+		t.Error("push should be paused at 99% quota")
+	}
+}
+
+func TestMonitor_HysteresisResume(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	// First poll: enter blocked state.
+	mon.Poll(context.Background())
+	if mon.State().State != StateBlocked {
+		t.Fatalf("expected blocked, got %s", mon.State().State)
+	}
+	if !push.IsPaused() {
+		t.Fatal("expected push paused after 99%")
+	}
+
+	// Drop to 93% which is below hysteresis (94%).
+	pub.Reset()
+	remote.SetQuota(93, 100)
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateWarned {
+		t.Errorf("expected state %q after drop to 93%%, got %q", StateWarned, snap.State)
+	}
+	if push.IsPaused() {
+		t.Error("push should have been resumed after dropping below hysteresis")
+	}
+	events := pub.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event on resume, got %d", len(events))
+	}
+	if events[0].Payload["type"] != "quota.warning" {
+		t.Errorf("expected quota.warning on resume, got %v", events[0].Payload["type"])
+	}
+}
+
+func TestMonitor_HysteresisStaysBlocked(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	// Enter blocked state.
+	mon.Poll(context.Background())
+	if mon.State().State != StateBlocked {
+		t.Fatalf("expected blocked, got %s", mon.State().State)
+	}
+	pausesBefore := push.PauseCount()
+
+	// Drop to 95% which is above hysteresis (94%). Should stay blocked.
+	pub.Reset()
+	remote.SetQuota(95, 100)
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateBlocked {
+		t.Errorf("expected state %q at 95%% (above hysteresis), got %q", StateBlocked, snap.State)
+	}
+	if push.PauseCount() != pausesBefore {
+		t.Error("should not have called PausePush again (no transition)")
+	}
+	if len(pub.Events()) != 0 {
+		t.Errorf("expected no events (no transition), got %d", len(pub.Events()))
+	}
+}
+
+func TestMonitor_DuplicatePollNoReEmit(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 91, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	// First poll: transitions normal -> warned, emits event.
+	mon.Poll(context.Background())
+	if len(pub.Events()) != 1 {
+		t.Fatalf("expected 1 event after first poll, got %d", len(pub.Events()))
+	}
+
+	// Second poll at same level: no transition, no event.
+	pub.Reset()
+	mon.Poll(context.Background())
+	if len(pub.Events()) != 0 {
+		t.Errorf("expected no events on duplicate poll, got %d", len(pub.Events()))
+	}
+
+	// Third poll at same level: still no event.
+	mon.Poll(context.Background())
+	if len(pub.Events()) != 0 {
+		t.Errorf("expected no events on third duplicate poll, got %d", len(pub.Events()))
+	}
+}
+
+func TestMonitor_DryRun(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, true) // dry-run = true
+
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateBlocked {
+		t.Errorf("expected state %q (dry-run still tracks state), got %q", StateBlocked, snap.State)
+	}
+	// Quota event should still be emitted (observability is not suppressed).
+	events := pub.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event even in dry-run, got %d", len(events))
+	}
+	// But push should NOT be actually paused.
+	if push.IsPaused() {
+		t.Error("push should not be paused in dry-run mode")
+	}
+	if push.PauseCount() != 0 {
+		t.Error("PausePush should not have been called in dry-run mode")
+	}
+}
+
+func TestMonitor_QuotaPollError(t *testing.T) {
+	remote := &mockRemoteFS{
+		quota: QuotaInfo{Used: 50, Total: 100},
+		err:   fmt.Errorf("network timeout"),
+	}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateNormal {
+		t.Errorf("state should remain normal on poll error, got %q", snap.State)
+	}
+	if snap.LastError == "" {
+		t.Error("expected LastError to be set on poll failure")
+	}
+	if len(pub.Events()) != 0 {
+		t.Errorf("expected no events on poll error, got %d", len(pub.Events()))
+	}
+}
+
+func TestMonitor_NilPublisher(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 91, Total: 100}}
+	push := &mockPushController{}
+	mon := NewMonitor(remote, nil, push, DefaultConfig(), slog.Default())
+
+	// Should not panic with nil publisher.
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateWarned {
+		t.Errorf("expected warned, got %q", snap.State)
+	}
+}
+
+func TestMonitor_NilPushController(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	mon := NewMonitor(remote, pub, nil, DefaultConfig(), slog.Default())
+
+	// Should not panic with nil push controller.
+	mon.Poll(context.Background())
+
+	snap := mon.State()
+	if snap.State != StateBlocked {
+		t.Errorf("expected blocked, got %q", snap.State)
+	}
+}
+
+func TestQuotaInfo_UsedPercent(t *testing.T) {
+	tests := []struct {
+		name string
+		qi   QuotaInfo
+		want float64
+	}{
+		{"half", QuotaInfo{Used: 50, Total: 100}, 50},
+		{"full", QuotaInfo{Used: 100, Total: 100}, 100},
+		{"empty", QuotaInfo{Used: 0, Total: 100}, 0},
+		{"zero_total", QuotaInfo{Used: 50, Total: 0}, 0},
+		{"negative_total", QuotaInfo{Used: 50, Total: -1}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.qi.UsedPercent()
+			if got != tt.want {
+				t.Errorf("UsedPercent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMonitor_RunCancellation(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 50, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	cfg := DefaultConfig()
+	cfg.PollInterval = 10 * time.Millisecond // fast poll for test
+	mon := NewMonitor(remote, pub, push, cfg, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mon.Run(ctx)
+	}()
+
+	// Let it run a few poll cycles.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit after context cancellation")
+	}
+}
+
+func TestMonitor_FullLifecycle(t *testing.T) {
+	// Simulate: normal -> warned -> blocked -> hysteresis resume -> normal.
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 50, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+	ctx := context.Background()
+
+	// Step 1: normal at 50%.
+	mon.Poll(ctx)
+	if mon.State().State != StateNormal {
+		t.Fatalf("step 1: expected normal, got %s", mon.State().State)
+	}
+
+	// Step 2: rise to 91% -> warned.
+	remote.SetQuota(91, 100)
+	mon.Poll(ctx)
+	if mon.State().State != StateWarned {
+		t.Fatalf("step 2: expected warned, got %s", mon.State().State)
+	}
+
+	// Step 3: rise to 99% -> blocked.
+	remote.SetQuota(99, 100)
+	mon.Poll(ctx)
+	if mon.State().State != StateBlocked {
+		t.Fatalf("step 3: expected blocked, got %s", mon.State().State)
+	}
+	if !push.IsPaused() {
+		t.Fatal("step 3: expected push paused")
+	}
+
+	// Step 4: drop to 95%, still above hysteresis -> stays blocked.
+	remote.SetQuota(95, 100)
+	mon.Poll(ctx)
+	if mon.State().State != StateBlocked {
+		t.Fatalf("step 4: expected blocked (hysteresis), got %s", mon.State().State)
+	}
+
+	// Step 5: drop to 93%, below hysteresis -> resumes to warned.
+	remote.SetQuota(93, 100)
+	mon.Poll(ctx)
+	if mon.State().State != StateWarned {
+		t.Fatalf("step 5: expected warned, got %s", mon.State().State)
+	}
+	if push.IsPaused() {
+		t.Fatal("step 5: expected push resumed")
+	}
+
+	// Step 6: drop to 50% -> normal.
+	remote.SetQuota(50, 100)
+	mon.Poll(ctx)
+	if mon.State().State != StateNormal {
+		t.Fatalf("step 6: expected normal, got %s", mon.State().State)
+	}
+}

--- a/homedrive/internal/quota/quota_test.go
+++ b/homedrive/internal/quota/quota_test.go
@@ -2,6 +2,7 @@ package quota
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -352,5 +353,38 @@ func TestMonitor_FullLifecycle(t *testing.T) {
 	mon.Poll(ctx)
 	if mon.State().State != StateNormal {
 		t.Fatalf("step 6: expected normal, got %s", mon.State().State)
+	}
+}
+
+func TestMonitor_PollErrorWhileBlocked(t *testing.T) {
+	remote := &mockRemoteFS{quota: QuotaInfo{Used: 99, Total: 100}}
+	pub := &mockPublisher{}
+	push := &mockPushController{}
+	mon := newTestMonitor(t, remote, pub, push, false)
+	ctx := context.Background()
+
+	// Drive into blocked state.
+	mon.Poll(ctx)
+	if mon.State().State != StateBlocked {
+		t.Fatalf("setup: expected blocked, got %s", mon.State().State)
+	}
+	if !push.IsPaused() {
+		t.Fatal("setup: expected push paused")
+	}
+
+	// Inject consecutive poll errors.
+	remote.SetError(errors.New("network error"))
+	mon.Poll(ctx)
+	mon.Poll(ctx)
+
+	// State must stay blocked — cannot safely resume without knowing quota.
+	if s := mon.State(); s.State != StateBlocked {
+		t.Errorf("expected blocked after poll errors, got %s", s.State)
+	}
+	if !push.IsPaused() {
+		t.Error("expected push still paused after poll errors")
+	}
+	if mon.State().LastError == "" {
+		t.Error("expected LastError to be set after poll errors")
 	}
 }

--- a/homedrive/internal/quota/quota_test.go
+++ b/homedrive/internal/quota/quota_test.go
@@ -272,22 +272,31 @@ func TestQuotaInfo_UsedPercent(t *testing.T) {
 }
 
 func TestMonitor_RunCancellation(t *testing.T) {
-	remote := &mockRemoteFS{quota: QuotaInfo{Used: 50, Total: 100}}
+	inner := &mockRemoteFS{quota: QuotaInfo{Used: 50, Total: 100}}
+	pollCh := make(chan struct{}, 10)
+	remote := &notifyingRemoteFS{inner: inner, ch: pollCh}
 	pub := &mockPublisher{}
 	push := &mockPushController{}
 	cfg := DefaultConfig()
-	cfg.PollInterval = 10 * time.Millisecond // fast poll for test
+	cfg.PollInterval = 10 * time.Millisecond
 	mon := NewMonitor(remote, pub, push, cfg, slog.Default())
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	done := make(chan error, 1)
 	go func() {
 		done <- mon.Run(ctx)
 	}()
 
-	// Let it run a few poll cycles.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for 3 confirmed poll cycles before cancelling.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-pollCh:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("poll %d did not fire within 2s", i+1)
+		}
+	}
 	cancel()
 
 	select {


### PR DESCRIPTION
## Summary

- New `internal/quota/` package implementing periodic quota polling with a three-state machine (normal / warned / blocked) and hysteresis to prevent flapping
- Push workers are paused when quota reaches `stop_push_pct` (default 99%) and resumed when usage drops below the hysteresis threshold (default 94%)
- MQTT `quota.warning` and `quota.exhausted` events emitted on state transitions; `--dry-run` mode polls and logs but does not actually pause workers

## Fixes applied after review

- **Deadlock prevention**: `poll()` no longer holds `m.mu` while calling MQTT publish or push pause/resume; lock is released before all external interface calls
- **Poll error behavior**: explicitly documented and tested that `StateBlocked` persists through poll errors — resuming without a known quota level would be unsafe; `TestMonitor_PollErrorWhileBlocked` pins this
- **Misleading comment**: `applyTransition` StateNormal case comment corrected — push is only ever paused in StateBlocked, not StateWarned
- **Flaky test**: `TestMonitor_RunCancellation` replaced `time.Sleep(50ms)` with a `notifyingRemoteFS` channel that waits for 3 confirmed poll cycles before cancelling

## PLAN.md Phase 10 reference

> Periodic `Quota()` poll (every 5min). At `warn_pct`: MQTT warning event.
> At `stop_push_pct`: pause push workers, keep pull running, MQTT
> `quota.exhausted` event, status reflects `quota_blocked`.
> Resume pushes when quota drops below `stop_push_pct - 5%` (hysteresis).

## Test coverage

94%+ on the quota package; all tests pass with `-race` on macOS and Linux.