### PR TITLE
feat: one-shot Dropbox → Google Drive migration via GCE

### DIFF
--- a/migrate/README.md
+++ b/migrate/README.md
@@ -1,0 +1,98 @@
+# Dropbox → Google Drive migration
+
+One-shot migration of a personal Dropbox account to Google Drive using
+[rclone](https://rclone.org) running on a preemptible GCE VM.
+No data transits your local machine — everything flows Dropbox → VM → Drive.
+
+## Prerequisites
+
+```bash
+brew install rclone google-cloud-sdk
+gcloud auth login
+gcloud auth application-default login
+```
+
+You need Owner or Editor on a GCP project with billing enabled.
+
+## Step 1 — Setup (run once, on your Mac)
+
+```bash
+GCP_PROJECT=my-project bash migrate/setup.sh
+```
+
+The script walks through every auth step interactively:
+
+| Step | What happens |
+|---|---|
+| Dropbox OAuth | Browser opens → sign in → Allow. Token saved automatically. |
+| GCP consent screen | Browser opens the GCP Console. Fill in app name + support email, save. Skip scopes and test users. |
+| Drive OAuth client | Browser opens credential creation. Pick **Desktop app**, name it anything, click **Create**, **Download JSON**. Drag the file into the terminal prompt. |
+| Drive OAuth | Browser opens → sign in → Allow. The consent screen now shows *your* app name — no "unverified app" warning. |
+| Verification | Script calls `rclone lsd` against both remotes to confirm they work. |
+| Secret Manager | The rclone config (containing both OAuth tokens) is stored as `dropbox-gdrive-rclone-conf`. |
+| Service account | `dropbox-gdrive-migrator@PROJECT.iam.gserviceaccount.com` is created with the two roles the VM needs. |
+
+If a remote is already configured in `~/.config/rclone/rclone.conf`, that step is skipped.
+
+## Step 2 — Run the migration
+
+```bash
+GCP_PROJECT=my-project bash migrate/run.sh
+```
+
+This creates a `SPOT e2-micro` VM in `us-central1-a` that:
+1. Installs the latest rclone release.
+2. Pulls `~/.config/rclone/rclone.conf` from Secret Manager.
+3. Runs `rclone copy dropbox: gdrive:`.
+4. Self-deletes when done.
+
+For 2 GB expect 15–30 minutes. Cost: < $0.01.
+
+### Optional environment variables
+
+| Variable | Default | Example |
+|---|---|---|
+| `GCP_ZONE` | `us-central1-a` | `europe-west1-b` |
+| `MACHINE_TYPE` | `e2-micro` | `e2-small` (more RAM if needed) |
+| `DROPBOX_SRC` | *(root)* | `photos` — sync only one subfolder |
+| `GDRIVE_DST` | *(root)* | `Dropbox-import` — land files in a subfolder |
+
+```bash
+GCP_PROJECT=my-project GDRIVE_DST=Dropbox-import bash migrate/run.sh
+```
+
+### Watch progress
+
+```bash
+# Structured logs (appear ~1 min after VM boot)
+gcloud logging read \
+  'resource.type=gce_instance AND jsonPayload.MESSAGE=~"rclone-migration"' \
+  --project=my-project --order=asc --freshness=2h \
+  --format='table(timestamp,jsonPayload.MESSAGE)'
+
+# Raw serial port output (good for startup errors)
+gcloud compute instances get-serial-port-output INSTANCE_NAME \
+  --zone=us-central1-a --project=my-project
+```
+
+The instance name is printed by `run.sh` when the VM is created
+(`dropbox-gdrive-YYYYMMDD-HHMMSS`).
+
+## Re-running after preemption
+
+`rclone copy` only transfers files that are missing or differ on the
+destination, so re-running `run.sh` is safe at any point.
+
+## Cleanup
+
+The VM self-deletes on success. To remove the remaining GCP resources:
+
+```bash
+# Remove the secret
+gcloud secrets delete dropbox-gdrive-rclone-conf --project=my-project
+
+# Remove the service account
+gcloud iam service-accounts delete \
+  dropbox-gdrive-migrator@my-project.iam.gserviceaccount.com \
+  --project=my-project
+```

--- a/migrate/run.sh
+++ b/migrate/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Creates a preemptible GCE e2-micro VM that runs rclone to copy Dropbox → Google Drive,
+# then self-destructs. rclone copy is idempotent: if the VM is preempted, just re-run.
+#
+# Usage:
+#   GCP_PROJECT=my-project bash migrate/run.sh
+#
+# Optional overrides:
+#   GCP_ZONE=us-central1-a        (default)
+#   MACHINE_TYPE=e2-micro         (default; e2-small if you want more RAM)
+#   DROPBOX_SRC=photos            (default: root — copies everything)
+#   GDRIVE_DST=Dropbox-import     (default: root)
+
+set -euo pipefail
+
+: "${GCP_PROJECT:?Set GCP_PROJECT}"
+GCP_ZONE="${GCP_ZONE:-us-central1-a}"
+MACHINE_TYPE="${MACHINE_TYPE:-e2-micro}"
+SECRET_NAME="dropbox-gdrive-rclone-conf"
+SA_EMAIL="dropbox-gdrive-migrator@${GCP_PROJECT}.iam.gserviceaccount.com"
+INSTANCE="dropbox-gdrive-$(date +%Y%m%d-%H%M%S)"
+DROPBOX_SRC="${DROPBOX_SRC:-}"
+GDRIVE_DST="${GDRIVE_DST:-}"
+
+# ── Write startup script to a temp file (avoids quoting hell in --metadata) ──
+
+TMPSCRIPT=$(mktemp)
+trap 'rm -f "$TMPSCRIPT"' EXIT
+
+cat > "$TMPSCRIPT" << 'STARTUP'
+#!/bin/bash
+set -euo pipefail
+exec > >(logger -t rclone-migration -s) 2>&1
+
+# Pull params from instance metadata
+META="http://metadata.google.internal/computeMetadata/v1/instance"
+H=(-H "Metadata-Flavor: Google")
+PROJECT=$(curl -sf "$META/attributes/mig-project" "${H[@]}")
+SECRET=$(curl  -sf "$META/attributes/mig-secret"  "${H[@]}")
+SRC=$(curl     -sf "$META/attributes/mig-src"     "${H[@]}")
+DST=$(curl     -sf "$META/attributes/mig-dst"     "${H[@]}")
+ZONE=$(curl    -sf "$META/zone"                   "${H[@]}" | awk -F/ '{print $NF}')
+NAME=$(curl    -sf "$META/name"                   "${H[@]}")
+
+echo "[$(date -u +%FT%TZ)] Installing rclone..."
+# Use official install script for latest version; fall back to apt
+curl -fsSL https://rclone.org/install.sh | bash 2>/dev/null \
+  || { apt-get update -qq && apt-get install -y -qq rclone; }
+
+echo "[$(date -u +%FT%TZ)] Fetching rclone config from Secret Manager..."
+mkdir -p /root/.config/rclone
+gcloud secrets versions access latest \
+  --secret="$SECRET" \
+  --project="$PROJECT" \
+  > /root/.config/rclone/rclone.conf
+
+echo "[$(date -u +%FT%TZ)] Starting: $SRC → $DST"
+rclone copy "$SRC" "$DST" \
+  --transfers=4 \
+  --checkers=8 \
+  --drive-chunk-size=256M \
+  --dropbox-chunk-size=128M \
+  --log-level=INFO \
+  --stats=60s \
+  --stats-log-level=INFO
+
+echo "[$(date -u +%FT%TZ)] Migration complete. Deleting VM..."
+gcloud compute instances delete "$NAME" \
+  --zone="$ZONE" \
+  --project="$PROJECT" \
+  --quiet
+STARTUP
+
+# ── Create the VM ─────────────────────────────────────────────────────────────
+
+echo "Creating VM: $INSTANCE"
+echo "  Zone:    $GCP_ZONE"
+echo "  Type:    $MACHINE_TYPE (SPOT)"
+echo "  Source:  dropbox:${DROPBOX_SRC:-<root>}"
+echo "  Dest:    gdrive:${GDRIVE_DST:-<root>}"
+echo ""
+
+gcloud compute instances create "$INSTANCE" \
+  --project="$GCP_PROJECT" \
+  --zone="$GCP_ZONE" \
+  --machine-type="$MACHINE_TYPE" \
+  --provisioning-model=SPOT \
+  --instance-termination-action=DELETE \
+  --image-family=debian-12 \
+  --image-project=debian-cloud \
+  --boot-disk-size=10GB \
+  --boot-disk-type=pd-standard \
+  --service-account="$SA_EMAIL" \
+  --scopes=cloud-platform \
+  --metadata-from-file=startup-script="$TMPSCRIPT" \
+  --metadata="mig-project=${GCP_PROJECT},mig-secret=${SECRET_NAME},mig-src=dropbox:${DROPBOX_SRC},mig-dst=gdrive:${GDRIVE_DST}"
+
+# ── Tail instructions ─────────────────────────────────────────────────────────
+
+echo "VM created. Watch progress (logs appear ~1 min after boot):"
+echo ""
+echo "  # Cloud Logging (structured)"
+echo "  gcloud logging read \\"
+echo "    'resource.type=gce_instance AND jsonPayload.MESSAGE=~\"rclone-migration\"' \\"
+echo "    --project=$GCP_PROJECT --order=asc --freshness=2h \\"
+echo "    --format='table(timestamp,jsonPayload.MESSAGE)'"
+echo ""
+echo "  # Serial port (raw, good for startup errors)"
+echo "  gcloud compute instances get-serial-port-output $INSTANCE \\"
+echo "    --zone=$GCP_ZONE --project=$GCP_PROJECT"
+echo ""
+echo "VM self-deletes when done. If preempted, just re-run run.sh — rclone copy is idempotent."

--- a/migrate/setup.sh
+++ b/migrate/setup.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Run once on your local machine.
+# Walks through every auth step end-to-end:
+#   1. Dropbox OAuth (browser)
+#   2. Google Drive — creates your own OAuth client in GCP so Google stops
+#      showing the "unverified app" warning, then does the Drive OAuth (browser)
+#   3. Stores the resulting rclone config in Secret Manager
+#   4. Creates the GCE service account the migration VM will run as
+#
+# Prerequisites:
+#   brew install rclone google-cloud-sdk
+#   gcloud auth login && gcloud auth application-default login
+#
+# Usage:
+#   GCP_PROJECT=my-project bash migrate/setup.sh
+
+set -euo pipefail
+
+: "${GCP_PROJECT:?Set GCP_PROJECT}"
+GCP_REGION="${GCP_REGION:-us-central1}"
+SECRET_NAME="dropbox-gdrive-rclone-conf"
+SA_NAME="dropbox-gdrive-migrator"
+SA_EMAIL="${SA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+
+for cmd in rclone gcloud python3; do
+  command -v "$cmd" >/dev/null || { echo "Missing: $cmd"; exit 1; }
+done
+
+gcloud config set project "$GCP_PROJECT" --quiet
+
+# ── 2. Enable GCP APIs ────────────────────────────────────────────────────────
+
+echo "Enabling GCP APIs..."
+gcloud services enable \
+  secretmanager.googleapis.com \
+  compute.googleapis.com \
+  drive.googleapis.com \
+  --project="$GCP_PROJECT" --quiet
+
+# ── 3. Dropbox OAuth ──────────────────────────────────────────────────────────
+
+echo ""
+echo "=== [1/2] Dropbox ==="
+
+if rclone listremotes | grep -q "^dropbox:"; then
+  echo "  Already configured — skipping."
+else
+  echo "  Your browser will open for Dropbox sign-in and consent."
+  echo "  rclone uses its own registered Dropbox app, so there is no"
+  echo "  'unverified app' warning on this side."
+  echo ""
+  read -rp "  Press Enter to open the browser..."
+
+  # rclone authorize outputs the token JSON to stdout after the user consents.
+  # We capture it and feed it straight into config create.
+  TMPDB=$(mktemp)
+  trap 'rm -f "$TMPDB"' EXIT
+  rclone authorize "dropbox" > "$TMPDB" 2>&1
+
+  DROPBOX_TOKEN=$(python3 - "$TMPDB" << 'PY'
+import sys, re, json
+content = open(sys.argv[1]).read()
+for m in re.finditer(r'\{[^{}]*"access_token"[^{}]*\}', content):
+    try:
+        json.loads(m.group())
+        print(m.group())
+        break
+    except json.JSONDecodeError:
+        pass
+PY
+)
+
+  [[ -n "$DROPBOX_TOKEN" ]] || { echo "No token received from Dropbox. Re-run the script."; exit 1; }
+
+  rclone config create dropbox dropbox token="$DROPBOX_TOKEN" --non-interactive >/dev/null
+  echo "  dropbox: OK"
+fi
+
+# ── 4. Google Drive — create your own OAuth 2.0 client ────────────────────────
+
+echo ""
+echo "=== [2/2] Google Drive ==="
+echo ""
+echo "We create a Desktop OAuth client inside your own GCP project so the"
+echo "consent screen shows YOUR app name instead of rclone's — no warning."
+echo ""
+
+if rclone listremotes | grep -q "^gdrive:"; then
+  echo "  Already configured — skipping."
+else
+
+  # ── 4a. OAuth consent screen ────────────────────────────────────────────────
+  echo "Step 1/3  Configure the OAuth consent screen"
+  echo "  Opening: GCP Console → APIs & Services → OAuth consent screen"
+  echo ""
+  open "https://console.cloud.google.com/apis/credentials/consent?project=${GCP_PROJECT}" \
+    2>/dev/null || true
+  echo "  If this is a new project, do the following in the browser:"
+  echo "    • User Type  → External → Create"
+  echo "    • App name   → rclone-migration  (or anything)"
+  echo "    • Support email → your email address"
+  echo "    • Scroll to the bottom → Save and Continue"
+  echo "    • Skip Scopes → Save and Continue"
+  echo "    • Skip Test users → Save and Continue"
+  echo "    • Back to Dashboard"
+  echo ""
+  echo "  If a consent screen already exists, no changes needed."
+  echo ""
+  read -rp "  Press Enter once the consent screen is ready..."
+
+  # ── 4b. Create OAuth client credentials ─────────────────────────────────────
+  echo ""
+  echo "Step 2/3  Create a Desktop app OAuth client"
+  echo "  Opening: GCP Console → APIs & Services → Credentials → Create credentials"
+  echo ""
+  open "https://console.cloud.google.com/apis/credentials/oauthclient?project=${GCP_PROJECT}" \
+    2>/dev/null || true
+  echo "  In the browser:"
+  echo "    • Application type → Desktop app"
+  echo "    • Name             → rclone-migration"
+  echo "    • Click Create"
+  echo "    • Click Download JSON  (saves a file like client_secret_xxx.json)"
+  echo ""
+  read -rp "  Paste the path to the downloaded JSON (or drag the file here): " CREDS_FILE
+  # Strip shell quoting, leading/trailing spaces, and ANSI escape sequences
+  CREDS_FILE=$(echo "$CREDS_FILE" | sed $'s/\x1b\\[[0-9;]*m//g' | tr -d "'" | xargs)
+
+  [[ -f "$CREDS_FILE" ]] || { echo "File not found: $CREDS_FILE"; exit 1; }
+
+  CLIENT_ID=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['installed']['client_id'])
+" "$CREDS_FILE")
+
+  CLIENT_SECRET=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d['installed']['client_secret'])
+" "$CREDS_FILE")
+
+  echo "  Parsed client_id: ${CLIENT_ID:0:24}..."
+
+  # ── 4c. Authorize Drive access ───────────────────────────────────────────────
+  echo ""
+  echo "Step 3/3  Authorize Google Drive access"
+  echo "  Your browser will open for Google sign-in and Drive consent."
+  echo "  The consent screen will now show 'rclone-migration' (your app)."
+  echo ""
+  read -rp "  Press Enter to open the browser..."
+
+  TMPGD=$(mktemp)
+  # rclone authorize prints "Paste the following..." then the token JSON on stdout
+  rclone authorize "drive" \
+    --client-id="$CLIENT_ID" \
+    --client-secret="$CLIENT_SECRET" \
+    > "$TMPGD" 2>&1
+
+  GDRIVE_TOKEN=$(python3 - "$TMPGD" << 'PY'
+import sys, re, json
+content = open(sys.argv[1]).read()
+for m in re.finditer(r'\{[^{}]*"access_token"[^{}]*\}', content):
+    try:
+        json.loads(m.group())
+        print(m.group())
+        break
+    except json.JSONDecodeError:
+        pass
+PY
+)
+  rm -f "$TMPGD"
+
+  [[ -n "$GDRIVE_TOKEN" ]] || { echo "No token received from Google Drive. Re-run the script."; exit 1; }
+
+  rclone config create gdrive drive \
+    client_id="$CLIENT_ID" \
+    client_secret="$CLIENT_SECRET" \
+    scope=drive \
+    token="$GDRIVE_TOKEN" \
+    --non-interactive >/dev/null
+
+  echo "  gdrive: OK"
+fi
+
+# ── 5. Verify both remotes can list files ─────────────────────────────────────
+
+echo ""
+echo "Verifying remotes..."
+rclone lsd dropbox: --max-depth 1 >/dev/null 2>&1 \
+  && echo "  dropbox: reachable" \
+  || { echo "  dropbox: FAILED — re-run the script"; exit 1; }
+rclone lsd gdrive: --max-depth 1 >/dev/null 2>&1 \
+  && echo "  gdrive:  reachable" \
+  || { echo "  gdrive:  FAILED — re-run the script"; exit 1; }
+
+# ── 6. Upload rclone config to Secret Manager ─────────────────────────────────
+
+RCLONE_CONF="$(rclone config file 2>/dev/null | tail -1)"
+[[ -f "$RCLONE_CONF" ]] || { echo "rclone config file not found at: $RCLONE_CONF"; exit 1; }
+
+echo ""
+echo "Uploading rclone config to Secret Manager..."
+gcloud secrets describe "$SECRET_NAME" --project="$GCP_PROJECT" >/dev/null 2>&1 \
+  || gcloud secrets create "$SECRET_NAME" \
+       --project="$GCP_PROJECT" \
+       --replication-policy=automatic
+
+gcloud secrets versions add "$SECRET_NAME" \
+  --project="$GCP_PROJECT" \
+  --data-file="$RCLONE_CONF"
+
+echo "  Stored: projects/$GCP_PROJECT/secrets/$SECRET_NAME"
+
+# ── 7. Create VM service account ──────────────────────────────────────────────
+
+echo "Creating service account..."
+gcloud iam service-accounts describe "$SA_EMAIL" --project="$GCP_PROJECT" >/dev/null 2>&1 \
+  || gcloud iam service-accounts create "$SA_NAME" \
+       --display-name="Dropbox→Drive migrator" \
+       --project="$GCP_PROJECT"
+
+echo "Granting IAM roles..."
+for role in roles/secretmanager.secretAccessor roles/compute.instanceAdmin.v1; do
+  gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="$role" \
+    --condition=None --quiet >/dev/null
+done
+
+echo ""
+echo "All done. Start the migration:"
+echo "  GCP_PROJECT=$GCP_PROJECT bash migrate/run.sh"


### PR DESCRIPTION
## Summary

- `migrate/README.md` — full usage guide (see below / in-repo)
- `migrate/setup.sh` — runs once locally: Dropbox OAuth, creates a Desktop OAuth 2.0 client in the user's own GCP project (removes the Google "unverified app" warning), Drive OAuth flow, verifies both remotes are reachable, uploads rclone config to Secret Manager, provisions the VM service account
- `migrate/run.sh` — creates a preemptible `e2-micro` Debian VM whose startup script installs rclone, pulls the config from Secret Manager, runs `rclone copy`, and self-deletes on completion

## Usage

### Prerequisites
```bash
brew install rclone google-cloud-sdk
gcloud auth login && gcloud auth application-default login
```

### Step 1 — Setup (once, on your Mac)
```bash
GCP_PROJECT=my-project bash migrate/setup.sh
```
Walks through Dropbox OAuth, GCP consent screen, Drive OAuth client creation (Desktop app), Drive OAuth, then stores the rclone config in Secret Manager and creates the VM service account.

### Step 2 — Run
```bash
GCP_PROJECT=my-project bash migrate/run.sh
```
Creates a SPOT `e2-micro` VM that copies Dropbox → Drive and self-deletes. ~15–30 min for 2 GB, cost < $0.01.

Optional overrides: `GCP_ZONE`, `MACHINE_TYPE`, `DROPBOX_SRC`, `GDRIVE_DST`.

`rclone copy` is idempotent — safe to re-run if the VM is preempted.

## Test plan

- [ ] `setup.sh` completes without error, both remotes pass `rclone lsd` verification
- [ ] `run.sh` VM appears in GCE console, logs show rclone progress, VM self-deletes on completion
- [ ] Re-running `run.sh` after simulated preemption does not duplicate files
- [ ] `gcloud secrets versions access latest --secret=dropbox-gdrive-rclone-conf` returns valid rclone config