### PR TITLE
feat(pull): wire pull-down sync from Google Drive on startup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,8 +45,8 @@ nfpms:
         dst: /etc/sysctl.d/99-homedrive-inotify.conf
         type: config
       - src: homedrive/linux/config.yaml
-        dst: /etc/homedrive/config.yaml
-        type: config|noreplace
+        dst: /usr/share/doc/homedrive/config.yaml.example
+        type: doc
     scripts:
       postinstall: homedrive/linux/postinst.sh
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,9 @@ nfpms:
       - src: homedrive/linux/99-homedrive-inotify.conf
         dst: /etc/sysctl.d/99-homedrive-inotify.conf
         type: config
+      - src: homedrive/linux/config.yaml
+        dst: /etc/homedrive/config.yaml
+        type: config|noreplace
     scripts:
       postinstall: homedrive/linux/postinst.sh
 

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,11 @@ install-systemd:
 
 install-package: build-arm64 install-systemd
 	install -m 0755 $(DIST)/$(BINARY)-arm64 $(PREFIX)/bin/$(BINARY)
+	install -m 0644 $(LINUX_DIR)/99-homedrive-inotify.conf /etc/sysctl.d/
+	install -m 0644 $(LINUX_DIR)/homedrive.logrotate /etc/logrotate.d/homedrive
+	install -d -m 0755 /etc/homedrive
+	install -m 0644 $(LINUX_DIR)/config.yaml /etc/homedrive/config.yaml
 	$(LINUX_DIR)/postinst.sh
-	systemctl daemon-reload
 
 clean:
 	rm -rf $(DIST)

--- a/homedrive/cmd/homedrive/adapters.go
+++ b/homedrive/cmd/homedrive/adapters.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/asnowfix/home-drive/homedrive/internal/rcloneclient"
+	"github.com/asnowfix/home-drive/homedrive/internal/store"
+	"github.com/asnowfix/home-drive/homedrive/internal/syncer"
+)
+
+// ---------------------------------------------------------------------------
+// rcloneSyncerAdapter: *rcloneclient.RcloneFS → syncer.RemoteFS
+// ---------------------------------------------------------------------------
+
+type rcloneSyncerAdapter struct {
+	fs *rcloneclient.RcloneFS
+}
+
+func toSyncerObject(ro rcloneclient.RemoteObject) syncer.RemoteObject {
+	return syncer.RemoteObject{
+		Path:    ro.Path,
+		Size:    ro.Size,
+		MD5:     ro.MD5,
+		ModTime: ro.ModTime,
+		ID:      ro.RemoteID,
+	}
+}
+
+func (a *rcloneSyncerAdapter) CopyFile(ctx context.Context, src, dstDir string) (syncer.RemoteObject, error) {
+	ro, err := a.fs.CopyFile(ctx, src, dstDir)
+	return toSyncerObject(ro), err
+}
+
+func (a *rcloneSyncerAdapter) DeleteFile(ctx context.Context, path string) error {
+	return a.fs.DeleteFile(ctx, path)
+}
+
+func (a *rcloneSyncerAdapter) MoveFile(ctx context.Context, src, dst string) error {
+	return a.fs.MoveFile(ctx, src, dst)
+}
+
+func (a *rcloneSyncerAdapter) Stat(ctx context.Context, path string) (syncer.RemoteObject, error) {
+	ro, err := a.fs.Stat(ctx, path)
+	return toSyncerObject(ro), err
+}
+
+func (a *rcloneSyncerAdapter) List(ctx context.Context, dir string) ([]syncer.RemoteObject, error) {
+	ros, err := a.fs.List(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]syncer.RemoteObject, len(ros))
+	for i, ro := range ros {
+		result[i] = toSyncerObject(ro)
+	}
+	return result, nil
+}
+
+func (a *rcloneSyncerAdapter) ListChanges(ctx context.Context, pageToken string) (syncer.Changes, error) {
+	ch, err := a.fs.ListChanges(ctx, pageToken)
+	if err != nil {
+		return syncer.Changes{}, err
+	}
+	items := make([]syncer.Change, len(ch.Items))
+	for i, c := range ch.Items {
+		sc := syncer.Change{Path: c.Path, Deleted: c.Deleted}
+		if c.Object != nil {
+			sc.Object = toSyncerObject(*c.Object)
+		}
+		items[i] = sc
+	}
+	return syncer.Changes{Items: items, NextPageToken: ch.NextPageToken}, nil
+}
+
+func (a *rcloneSyncerAdapter) GetStartPageToken(ctx context.Context) (string, error) {
+	return a.fs.GetStartPageToken(ctx)
+}
+
+func (a *rcloneSyncerAdapter) DownloadFile(ctx context.Context, remotePath, localPath string) error {
+	return a.fs.DownloadFile(ctx, remotePath, localPath)
+}
+
+// ---------------------------------------------------------------------------
+// journalSyncerAdapter: *store.Journal → syncer.Store
+// ---------------------------------------------------------------------------
+
+type journalSyncerAdapter struct {
+	j      *store.Journal
+	logger *slog.Logger
+}
+
+func toSyncerJournalEntry(e store.JournalEntry) syncer.JournalEntry {
+	return syncer.JournalEntry{
+		Path:         e.Path,
+		LocalMtime:   e.LocalMtime,
+		RemoteMtime:  e.RemoteMtime,
+		RemoteMD5:    e.RemoteMD5,
+		RemoteID:     e.RemoteID,
+		LastSyncedAt: e.LastSyncedAt,
+		LastOrigin:   e.LastOrigin,
+	}
+}
+
+func toStoreJournalEntry(e syncer.JournalEntry) store.JournalEntry {
+	return store.JournalEntry{
+		Path:         e.Path,
+		LocalMtime:   e.LocalMtime,
+		RemoteMtime:  e.RemoteMtime,
+		RemoteMD5:    e.RemoteMD5,
+		RemoteID:     e.RemoteID,
+		LastSyncedAt: e.LastSyncedAt,
+		LastOrigin:   e.LastOrigin,
+	}
+}
+
+func (a *journalSyncerAdapter) GetPageToken(_ context.Context) (string, error) {
+	return a.j.GetPageToken()
+}
+
+func (a *journalSyncerAdapter) SetPageToken(_ context.Context, token string) error {
+	return a.j.SetPageToken(token)
+}
+
+func (a *journalSyncerAdapter) Get(_ context.Context, path string) (syncer.JournalEntry, bool, error) {
+	e, err := a.j.Get(path)
+	if err == store.ErrNotFound {
+		return syncer.JournalEntry{}, false, nil
+	}
+	if err != nil {
+		return syncer.JournalEntry{}, false, err
+	}
+	return toSyncerJournalEntry(e), true, nil
+}
+
+func (a *journalSyncerAdapter) Put(_ context.Context, entry syncer.JournalEntry) error {
+	return a.j.Put(toStoreJournalEntry(entry))
+}
+
+func (a *journalSyncerAdapter) Delete(_ context.Context, path string) error {
+	return a.j.Delete(path)
+}
+
+func (a *journalSyncerAdapter) NextOldN(_ context.Context, path string) (int, error) {
+	return a.j.NextOldN(path), nil
+}
+
+func (a *journalSyncerAdapter) RewritePrefix(_ context.Context, oldPrefix, newPrefix string) (int, error) {
+	return store.RewritePrefix(a.j, oldPrefix, newPrefix, nil, a.logger)
+}
+
+// ---------------------------------------------------------------------------
+// noopPublisher: satisfies syncer.Publisher when MQTT is disabled
+// ---------------------------------------------------------------------------
+
+type noopPublisher struct{}
+
+func (noopPublisher) PublishJSON(_ string, _ any) error { return nil }
+func (noopPublisher) Topic(parts ...string) string {
+	return strings.Join(parts, "/")
+}
+
+// ---------------------------------------------------------------------------
+// auditLoggerAdapter: *store.Auditor → syncer.AuditLogger
+// ---------------------------------------------------------------------------
+
+type auditLoggerAdapter struct {
+	a *store.Auditor
+}
+
+func (al *auditLoggerAdapter) Log(entry syncer.AuditEntry) error {
+	al.a.Log(store.AuditEntry{
+		Timestamp: entry.Timestamp,
+		Op:        entry.Op,
+		Path:      entry.Path,
+		DryRun:    entry.DryRun,
+		Error:     entry.Error,
+	})
+	return nil
+}

--- a/homedrive/cmd/homedrive/main.go
+++ b/homedrive/cmd/homedrive/main.go
@@ -113,7 +113,7 @@ func runAgent(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("open journal: %w", err)
 	}
-	defer journal.Close()
+	defer func() { _ = journal.Close() }()
 
 	var auditAdapter syncer.AuditLogger
 	if cfg.State.AuditLog != "" {
@@ -124,7 +124,7 @@ func runAgent(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("open audit log: %w", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		auditAdapter = &auditLoggerAdapter{a: store.NewAuditor(f, slog.Default())}
 	}
 

--- a/homedrive/cmd/homedrive/main.go
+++ b/homedrive/cmd/homedrive/main.go
@@ -4,14 +4,20 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
-	// Import rcloneclient to register the Drive backend at init time.
-	// This is the only rclone backend; binary stays < 25 MB.
-	_ "github.com/asnowfix/home-drive/homedrive/internal/rcloneclient"
+	"github.com/asnowfix/home-drive/homedrive/internal/config"
+	"github.com/asnowfix/home-drive/homedrive/internal/rcloneclient"
+	"github.com/asnowfix/home-drive/homedrive/internal/store"
+	"github.com/asnowfix/home-drive/homedrive/internal/syncer"
 )
 
 // version is set at build time via -ldflags.
@@ -63,20 +69,105 @@ func newRootCmd() *cobra.Command {
 }
 
 func newRunCmd() *cobra.Command {
-	return &cobra.Command{
+	var configPath string
+
+	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Start the sync agent",
 		RunE:  runAgent,
 	}
+	cmd.Flags().StringVar(&configPath, "config", "/etc/homedrive/config.yaml",
+		"path to config file")
+	return cmd
 }
 
 func runAgent(cmd *cobra.Command, _ []string) error {
 	dryRun, _ := cmd.Context().Value(DryRunKey).(bool)
+	configPath, _ := cmd.Flags().GetString("config")
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if dryRun {
+		cfg.DryRun = true
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfg.State.Path), 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.MkdirAll(cfg.LocalRoot, 0o755); err != nil {
+		return fmt.Errorf("create local root: %w", err)
+	}
+
+	journal, err := store.OpenJournal(cfg.State.Path, slog.Default())
+	if err != nil {
+		return fmt.Errorf("open journal: %w", err)
+	}
+	defer journal.Close()
+
+	var auditAdapter syncer.AuditLogger
+	if cfg.State.AuditLog != "" {
+		if err := os.MkdirAll(filepath.Dir(cfg.State.AuditLog), 0o755); err != nil {
+			return fmt.Errorf("create audit log dir: %w", err)
+		}
+		f, err := os.OpenFile(cfg.State.AuditLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+		if err != nil {
+			return fmt.Errorf("open audit log: %w", err)
+		}
+		defer f.Close()
+		auditAdapter = &auditLoggerAdapter{a: store.NewAuditor(f, slog.Default())}
+	}
+
 	slog.Info("starting homedrive agent",
 		"version", version,
-		"dry_run", dryRun,
+		"config", configPath,
+		"local_root", cfg.LocalRoot,
+		"remote", cfg.Remote,
+		"dry_run", cfg.DryRun,
 	)
-	// Phase 1+ will wire watcher, syncer, http, mqtt here.
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	rfs, err := rcloneclient.NewRcloneFS(ctx, rcloneclient.RcloneFSConfig{
+		Remote:     cfg.Remote,
+		ConfigPath: cfg.RcloneConfig,
+		Log:        slog.Default(),
+	})
+	if err != nil {
+		return fmt.Errorf("init rclone remote: %w", err)
+	}
+
+	interval := cfg.Pull.ChangesAPIInterval.Duration
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	puller := syncer.NewPuller(
+		syncer.PullerConfig{
+			Interval:       interval,
+			LocalRoot:      cfg.LocalRoot,
+			ConflictPolicy: syncer.ConflictPolicy(cfg.Conflict.Policy),
+			DryRun:         cfg.DryRun,
+		},
+		&rcloneSyncerAdapter{fs: rfs},
+		&journalSyncerAdapter{j: journal, logger: slog.Default()},
+		auditAdapter,
+		noopPublisher{},
+		slog.Default(),
+		time.Now,
+	)
+
+	pullerDone := make(chan error, 1)
+	go func() { pullerDone <- puller.Run(ctx) }()
+
+	<-ctx.Done()
+	err = <-pullerDone
+	slog.Info("homedrive agent stopped")
+	if err != nil && err != context.Canceled {
+		return err
+	}
 	return nil
 }
 
@@ -100,7 +191,6 @@ func newCtlStatusCmd() *cobra.Command {
 		Short: "Show agent status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			slog.Info("ctl: status requested")
-			// Phase 8 will call GET /status on the HTTP endpoint.
 			return nil
 		},
 	}
@@ -112,7 +202,6 @@ func newCtlPauseCmd() *cobra.Command {
 		Short: "Pause the sync agent",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			slog.Info("ctl: pause requested")
-			// Phase 8 will call POST /pause on the HTTP endpoint.
 			return nil
 		},
 	}
@@ -124,7 +213,6 @@ func newCtlResumeCmd() *cobra.Command {
 		Short: "Resume the sync agent",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			slog.Info("ctl: resume requested")
-			// Phase 8 will call POST /resume on the HTTP endpoint.
 			return nil
 		},
 	}
@@ -136,7 +224,6 @@ func newCtlResyncCmd() *cobra.Command {
 		Short: "Force an immediate bisync",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			slog.Info("ctl: resync requested")
-			// Phase 8 will call POST /resync on the HTTP endpoint.
 			return nil
 		},
 	}

--- a/homedrive/cmd/homedrive/main.go
+++ b/homedrive/cmd/homedrive/main.go
@@ -44,6 +44,15 @@ func main() {
 	}
 }
 
+// defaultConfigPath returns the XDG-compliant per-user config path.
+func defaultConfigPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "/etc/homedrive/config.yaml"
+	}
+	return filepath.Join(dir, "homedrive", "config.yaml")
+}
+
 func newRootCmd() *cobra.Command {
 	var dryRun bool
 
@@ -76,7 +85,7 @@ func newRunCmd() *cobra.Command {
 		Short: "Start the sync agent",
 		RunE:  runAgent,
 	}
-	cmd.Flags().StringVar(&configPath, "config", "/etc/homedrive/config.yaml",
+	cmd.Flags().StringVar(&configPath, "config", defaultConfigPath(),
 		"path to config file")
 	return cmd
 }

--- a/homedrive/cmd/homedrive/main_test.go
+++ b/homedrive/cmd/homedrive/main_test.go
@@ -70,10 +70,9 @@ func TestDryRunFlag_DefaultFalse(t *testing.T) {
 	var capturedCtx context.Context
 	for _, cmd := range root.Commands() {
 		if cmd.Name() == "run" {
-			original := cmd.RunE
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
 				capturedCtx = cmd.Context()
-				return original(cmd, args)
+				return nil // capture only; don't start the agent
 			}
 			break
 		}
@@ -103,10 +102,9 @@ func TestDryRunFlag_SetTrue(t *testing.T) {
 	var capturedCtx context.Context
 	for _, cmd := range root.Commands() {
 		if cmd.Name() == "run" {
-			original := cmd.RunE
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {
 				capturedCtx = cmd.Context()
-				return original(cmd, args)
+				return nil // capture only; don't start the agent
 			}
 			break
 		}

--- a/homedrive/docs/manual-validation.md
+++ b/homedrive/docs/manual-validation.md
@@ -1,0 +1,148 @@
+# Manual validation — installing homedrive on gruissan
+
+Validated on: 2026-05-31  
+Target: Debian 12 (bookworm) aarch64 — Raspberry Pi (`gruissan.local`, `192.168.1.2`)  
+User instance: `homedrive@fix.service`
+
+---
+
+## Prerequisites
+
+On the **development Mac**:
+
+- Go toolchain installed
+- `goreleaser` installed (`brew install goreleaser`)
+- SSH key at `~/.ssh/fix.kowalski@gmail.com_rsa` (user `fix`) and admin-capable key for user `admin`
+
+On the **NAS** (`gruissan`):
+
+- `rclone` installed (`/usr/bin/rclone v1.74.2`)
+- External drive mounted at `/media/fideco-sda1` (3.6 TB)
+- User `admin` has passwordless `sudo`
+
+---
+
+## 1. Build the .deb (on the Mac)
+
+```bash
+goreleaser release --snapshot --skip=publish --clean
+# produces: dist/homedrive_<version>_linux_arm64.deb
+```
+
+## 2. Copy the .deb to the NAS
+
+```bash
+scp -i ~/.ssh/fix.kowalski@gmail.com_rsa \
+  dist/homedrive_*_linux_arm64.deb \
+  fix@192.168.1.2:/tmp/
+```
+
+> Note: use the IP `192.168.1.2` rather than `gruissan.local` — the mDNS name
+> resolves with a trailing dot in `known_hosts` which causes host-key
+> verification to fail with `scp`.
+
+## 3. Install the package (on the NAS, as admin)
+
+```bash
+sudo dpkg -i /tmp/homedrive_*_linux_arm64.deb
+```
+
+This installs:
+
+| Path | Content |
+|---|---|
+| `/usr/bin/homedrive` | binary |
+| `/lib/systemd/system/homedrive@.service` | templated service unit |
+| `/etc/default/homedrive` | systemd env file (HOMEDRIVE_CONFIG, log level) |
+| `/etc/homedrive/config.yaml` | rich YAML config (config\|noreplace — not overwritten on upgrade) |
+| `/etc/sysctl.d/99-homedrive-inotify.conf` | inotify tuning (applied at install) |
+| `/etc/logrotate.d/homedrive` | weekly log rotation, keep 12 |
+
+## 4. Prepare the local sync root (on the NAS)
+
+Create the directory that will mirror Google Drive and give ownership to the
+service user:
+
+```bash
+mkdir -p /media/fideco-sda1/gdrive
+sudo chown fix:fix /media/fideco-sda1/gdrive
+```
+
+## 5. Configure rclone (on the Mac, then copy to the NAS)
+
+The service reads rclone config from `/home/fix/.config/rclone/rclone.conf`.
+Configure the `gdrive` remote on the Mac (where a browser is available for
+the OAuth flow), then copy it to the NAS:
+
+```bash
+# On the Mac — create/configure the remote named "gdrive":
+rclone config
+
+# Copy the resulting config to the NAS:
+scp -i ~/.ssh/fix.kowalski@gmail.com_rsa \
+  ~/.config/rclone/rclone.conf \
+  fix@192.168.1.2:~/.config/rclone/rclone.conf
+```
+
+## 6. Edit `/etc/homedrive/config.yaml` (on the NAS)
+
+Update at minimum:
+
+```yaml
+local_root: /media/fideco-sda1/gdrive   # actual mount path
+remote: gdrive:                          # must match the rclone remote name
+rclone_config: /home/fix/.config/rclone/rclone.conf
+```
+
+State and log paths use systemd-managed per-user directories
+(`StateDirectory=homedrive/%i` / `LogsDirectory=homedrive/%i`):
+
+```yaml
+state:
+  path: /var/lib/homedrive/fix/state.db
+  audit_log: /var/log/homedrive/fix/audit.jsonl
+```
+
+## 7. Enable and start the service (on the NAS, as admin)
+
+```bash
+sudo systemctl enable --now homedrive@fix.service
+sudo systemctl status homedrive@fix.service
+```
+
+Expected output (stub — sync not yet wired):
+
+```
+● homedrive@fix.service - homedrive sync agent for fix
+     Loaded: loaded (/lib/systemd/system/homedrive@.service; enabled; preset: enabled)
+     Active: active (running) since Sun 2026-05-31 21:48:19 CEST
+   Main PID: 395402 (homedrive)
+…
+May 31 21:48:19 gruissan homedrive[395402]: {"level":"INFO","msg":"starting homedrive agent","version":"0.0.0-SNAPSHOT-06a62c4","config":"/etc/homedrive/config.yaml","dry_run":false}
+```
+
+## 8. Verify logs
+
+```bash
+sudo journalctl -u homedrive@fix.service -f
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `unknown flag: --config` | old binary missing the flag | rebuild and reinstall the .deb |
+| `failed` with exit-code immediately | `Type=notify` without sd_notify | service now uses `Type=simple`; rebuild if still on old unit |
+| `Host key verification failed` on scp | mDNS trailing-dot in known_hosts | use IP `192.168.1.2` instead of `gruissan.local` |
+| state/log dirs missing | first start before systemd creates them | systemd creates them automatically on `systemctl start` |
+
+## Uninstalling
+
+```bash
+sudo dpkg -r homedrive
+# config files (/etc/homedrive/config.yaml, /etc/default/homedrive) are kept
+# by dpkg (config|noreplace). Remove manually if desired:
+sudo rm -rf /etc/homedrive /etc/default/homedrive
+```

--- a/homedrive/internal/config/config.go
+++ b/homedrive/internal/config/config.go
@@ -1,3 +1,122 @@
 // Package config loads homedrive configuration from YAML files,
 // /etc/default/homedrive environment variables, and CLI flags.
 package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the root homedrive configuration.
+type Config struct {
+	LocalRoot    string        `yaml:"local_root"`
+	Remote       string        `yaml:"remote"`
+	RcloneConfig string        `yaml:"rclone_config"`
+	Watcher      WatcherConfig `yaml:"watcher"`
+	Push         PushConfig    `yaml:"push"`
+	Pull         PullConfig    `yaml:"pull"`
+	Conflict     ConflictCfg   `yaml:"conflict"`
+	State        StateConfig   `yaml:"state"`
+	HTTP         HTTPConfig    `yaml:"http"`
+	MQTT         MQTTConfig    `yaml:"mqtt"`
+	Logging      LoggingConfig `yaml:"logging"`
+	Quota        QuotaConfig   `yaml:"quota"`
+	DryRun       bool          `yaml:"dry_run"`
+}
+
+// WatcherConfig configures the fsnotify watcher.
+type WatcherConfig struct {
+	Debounce            Duration `yaml:"debounce"`
+	DirRenamePairWindow Duration `yaml:"dir_rename_pair_window"`
+	Exclude             []string `yaml:"exclude"`
+}
+
+// PushConfig configures the push worker pool.
+type PushConfig struct {
+	Workers int         `yaml:"workers"`
+	Retry   RetryConfig `yaml:"retry"`
+}
+
+// RetryConfig configures exponential backoff for push retries.
+type RetryConfig struct {
+	MaxAttempts    int      `yaml:"max_attempts"`
+	InitialBackoff Duration `yaml:"initial_backoff"`
+	MaxBackoff     Duration `yaml:"max_backoff"`
+}
+
+// PullConfig configures the pull loop.
+type PullConfig struct {
+	ChangesAPIInterval Duration `yaml:"changes_api_interval"`
+	BisyncInterval     Duration `yaml:"bisync_interval"`
+}
+
+// ConflictCfg configures conflict resolution.
+type ConflictCfg struct {
+	Policy          string `yaml:"policy"`
+	OldSuffixFormat string `yaml:"old_suffix_format"`
+}
+
+// StateConfig configures BoltDB and audit log paths.
+type StateConfig struct {
+	Path     string `yaml:"path"`
+	AuditLog string `yaml:"audit_log"`
+}
+
+// HTTPConfig configures the control endpoint.
+type HTTPConfig struct {
+	Listen  string `yaml:"listen"`
+	Metrics bool   `yaml:"metrics"`
+}
+
+// MQTTConfig configures the MQTT publisher.
+type MQTTConfig struct {
+	Enabled           bool     `yaml:"enabled"`
+	Broker            string   `yaml:"broker"`
+	ClientIDPrefix    string   `yaml:"client_id_prefix"`
+	BaseTopic         string   `yaml:"base_topic"`
+	HADiscoveryPrefix string   `yaml:"ha_discovery_prefix"`
+	PublishInterval   Duration `yaml:"publish_interval"`
+	QoS               byte     `yaml:"qos"`
+}
+
+// LoggingConfig configures log level and format.
+type LoggingConfig struct {
+	Level  string `yaml:"level"`
+	Format string `yaml:"format"`
+}
+
+// QuotaConfig configures Drive quota thresholds.
+type QuotaConfig struct {
+	WarnPct     float64 `yaml:"warn_pct"`
+	StopPushPct float64 `yaml:"stop_push_pct"`
+}
+
+// Duration wraps time.Duration to support YAML unmarshaling of "2s", "500ms".
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	dur, err := time.ParseDuration(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", value.Value, err)
+	}
+	d.Duration = dur
+	return nil
+}
+
+// Load reads and parses the YAML config file at path.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config: read %q: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config: parse %q: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/homedrive/internal/rcloneclient/rclonefs.go
+++ b/homedrive/internal/rcloneclient/rclonefs.go
@@ -3,7 +3,9 @@ package rcloneclient
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	// Single rclone backend -- keep this as the ONLY backend import.
@@ -126,22 +128,108 @@ func (r *RcloneFS) Stat(ctx context.Context, remotePath string) (RemoteObject, e
 	return remoteObjectFromRclone(obj), nil
 }
 
-// ListChanges returns changes since the given page token.
+// GetStartPageToken returns the sentinel token that triggers a full
+// remote walk on the first pull cycle.
+func (r *RcloneFS) GetStartPageToken(_ context.Context) (string, error) {
+	return "initial_sync", nil
+}
+
+// ListChanges returns remote changes since the given page token.
 //
-// This method uses the Drive Changes API, which requires casting the rclone
-// Fs to the drive-specific type. This is the one place where the wrapper
-// abstraction leaks -- the cast is necessary because rclone's operations
-// package does not expose the Changes API generically.
+// When pageToken == "initial_sync", performs a full recursive walk of
+// the remote and returns every file as a change, triggering a complete
+// pull on first startup or after a token reset.
 //
-// For Phase 2 the implementation returns a placeholder; the full Drive
-// Changes API integration lands in Phase 6.
-func (r *RcloneFS) ListChanges(_ context.Context, pageToken string) (Changes, error) {
-	// TODO(phase-6): implement via drive.Fs cast for Changes API.
-	r.log.Info("ListChanges not yet implemented",
-		"op", "ListChanges",
-		"page_token", pageToken,
-	)
-	return Changes{NextPageToken: pageToken}, nil
+// Any other token returns empty changes with the same stable token
+// until the Drive Changes API is wired in.
+func (r *RcloneFS) ListChanges(ctx context.Context, pageToken string) (Changes, error) {
+	if pageToken != "initial_sync" {
+		return Changes{NextPageToken: pageToken}, nil
+	}
+
+	r.log.Info("ListChanges: full remote walk (initial sync)", "op", "ListChanges")
+
+	var items []Change
+	if err := r.listRecursive(ctx, "", &items); err != nil {
+		return Changes{}, fmt.Errorf("rcloneclient: walk for initial sync: %w", err)
+	}
+
+	r.log.Info("ListChanges: walk complete", "files", len(items))
+	return Changes{Items: items, NextPageToken: "synced"}, nil
+}
+
+// listRecursive walks dir on the remote Fs, appending file changes to items.
+func (r *RcloneFS) listRecursive(ctx context.Context, dir string, items *[]Change) error {
+	entries, err := r.fsObj.List(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("list %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		switch v := entry.(type) {
+		case rclonefs.Object:
+			ro := remoteObjectFromRclone(v)
+			*items = append(*items, Change{Path: ro.Path, Object: &ro})
+		default:
+			if err := r.listRecursive(ctx, entry.Remote(), items); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DownloadFile downloads the remote file at remotePath to localPath,
+// preserving the remote mtime for loop-prevention.
+func (r *RcloneFS) DownloadFile(ctx context.Context, remotePath, localPath string) error {
+	obj, err := r.fsObj.NewObject(ctx, remotePath)
+	if err != nil {
+		return fmt.Errorf("rcloneclient: open remote %q: %w", remotePath, err)
+	}
+
+	rc, err := obj.Open(ctx)
+	if err != nil {
+		return fmt.Errorf("rcloneclient: open stream %q: %w", remotePath, err)
+	}
+	defer rc.Close()
+
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return fmt.Errorf("rcloneclient: mkdirall for %q: %w", localPath, err)
+	}
+
+	f, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("rcloneclient: create %q: %w", localPath, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, rc); err != nil {
+		return fmt.Errorf("rcloneclient: download %q: %w", localPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("rcloneclient: close %q: %w", localPath, err)
+	}
+
+	mtime := obj.ModTime(ctx)
+	if err := os.Chtimes(localPath, mtime, mtime); err != nil {
+		r.log.Warn("failed to preserve mtime after download",
+			"path", localPath, "error", err)
+	}
+	return nil
+}
+
+// List returns all objects in the given remote directory (non-recursive).
+func (r *RcloneFS) List(ctx context.Context, dir string) ([]RemoteObject, error) {
+	entries, err := r.fsObj.List(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("rcloneclient: list %q: %w", dir, err)
+	}
+	var objs []RemoteObject
+	for _, entry := range entries {
+		if obj, ok := entry.(rclonefs.Object); ok {
+			objs = append(objs, remoteObjectFromRclone(obj))
+		}
+	}
+	return objs, nil
 }
 
 // Quota returns the current remote storage usage via fs.About.
@@ -182,9 +270,8 @@ func remoteObjectFromRclone(obj rclonefs.Object) RemoteObject {
 		ro.RemoteID = ider.ID()
 	}
 
-	// MD5 extraction deferred -- requires fs/hash import which is not in
-	// the allow-list. Will be added when Phase 6 (Pull via Changes API)
-	// needs it, with binary size verification.
+	// MD5 extraction requires fs/hash which would add rclone backend imports
+	// beyond the allowed set; omitted until the Drive Changes API needs it.
 
 	return ro
 }

--- a/homedrive/internal/rcloneclient/rclonefs.go
+++ b/homedrive/internal/rcloneclient/rclonefs.go
@@ -190,7 +190,7 @@ func (r *RcloneFS) DownloadFile(ctx context.Context, remotePath, localPath strin
 	if err != nil {
 		return fmt.Errorf("rcloneclient: open stream %q: %w", remotePath, err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return fmt.Errorf("rcloneclient: mkdirall for %q: %w", localPath, err)
@@ -200,7 +200,7 @@ func (r *RcloneFS) DownloadFile(ctx context.Context, remotePath, localPath strin
 	if err != nil {
 		return fmt.Errorf("rcloneclient: create %q: %w", localPath, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, rc); err != nil {
 		return fmt.Errorf("rcloneclient: download %q: %w", localPath, err)

--- a/homedrive/internal/store/journal.go
+++ b/homedrive/internal/store/journal.go
@@ -15,7 +15,10 @@ import (
 // Bucket names used inside the BoltDB file.
 var (
 	bucketJournal = []byte("journal")
+	bucketMeta    = []byte("meta")
 )
+
+var keyPageToken = []byte("page_token")
 
 // Sentinel errors for the store package.
 var (
@@ -49,7 +52,10 @@ func OpenJournal(path string, logger *slog.Logger) (*Journal, error) {
 	}
 
 	if err := db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists(bucketJournal)
+		if _, err := tx.CreateBucketIfNotExists(bucketJournal); err != nil {
+			return err
+		}
+		_, err := tx.CreateBucketIfNotExists(bucketMeta)
 		return err
 	}); err != nil {
 		_ = db.Close()
@@ -147,6 +153,46 @@ func (j *Journal) Count() (int, error) {
 // that need transactional access (e.g. bulk rename).
 func (j *Journal) DB() *bolt.DB {
 	return j.db
+}
+
+// GetPageToken retrieves the persisted Drive Changes API page token.
+// Returns an empty string if no token has been stored yet.
+func (j *Journal) GetPageToken() (string, error) {
+	var token string
+	err := j.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return nil
+		}
+		if v := b.Get(keyPageToken); v != nil {
+			token = string(v)
+		}
+		return nil
+	})
+	return token, err
+}
+
+// SetPageToken persists the Drive Changes API page token.
+func (j *Journal) SetPageToken(token string) error {
+	return j.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketMeta)
+		if b == nil {
+			return fmt.Errorf("store: meta bucket missing")
+		}
+		return b.Put(keyPageToken, []byte(token))
+	})
+}
+
+// NextOldN returns the smallest positive N such that "<path>.old.<N>"
+// has no journal entry, used when computing conflict loser filenames.
+func (j *Journal) NextOldN(path string) int {
+	n := 1
+	for {
+		if !j.Exists(fmt.Sprintf("%s.old.%d", path, n)) {
+			return n
+		}
+		n++
+	}
 }
 
 // hasPrefix checks whether key starts with prefix (byte-level comparison).

--- a/homedrive/internal/syncer/pull_process.go
+++ b/homedrive/internal/syncer/pull_process.go
@@ -81,6 +81,14 @@ func (p *Puller) processFileChange(ctx context.Context, ch Change, start time.Ti
 		if isConflict {
 			return p.handleConflict(ctx, ch, journal, localMtime, start)
 		}
+		// Remote mtime unchanged since last recorded sync: already in sync, skip.
+		diff := ch.Object.ModTime.Sub(journal.RemoteMtime)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff <= time.Second {
+			return nil
+		}
 	}
 
 	return p.downloadFile(ctx, ch, start)

--- a/homedrive/linux/config.yaml
+++ b/homedrive/linux/config.yaml
@@ -1,0 +1,76 @@
+# /etc/homedrive/config.yaml — default configuration.
+# Adjust local_root, remote, and rclone_config before starting the service.
+# Enable: systemctl enable --now homedrive@fix.service
+
+local_root: /mnt/external/gdrive
+remote: "gdrive:"
+rclone_config: /home/fix/.config/rclone/rclone.conf
+
+watcher:
+  debounce: 2s
+  dir_rename_pair_window: 500ms
+  exclude:
+    - "**/.git/**"
+    - "**/.svn/**"
+    - "**/.hg/**"
+    - "**/.DS_Store"
+    - "**/Thumbs.db"
+    - "**/desktop.ini"
+    - "**/*.swp"
+    - "**/*.swo"
+    - "**/*~"
+    - "**/.#*"
+    - "**/~$*"
+    - "**/.~lock.*"
+    - "**/node_modules/**"
+    - "**/.venv/**"
+    - "**/__pycache__/**"
+    - "**/.idea/**"
+    - "**/.vscode/**"
+    - "**/*.tmp"
+    - "**/*.partial"
+    - "**/*.crdownload"
+
+push:
+  workers: 2
+  retry:
+    max_attempts: 5
+    initial_backoff: 5s
+    max_backoff: 5m
+
+pull:
+  changes_api_interval: 30s
+  bisync_interval: 1h
+
+conflict:
+  policy: newer_wins
+  old_suffix_format: ".old.%d"
+
+state:
+  # systemd StateDirectory=homedrive/%i creates /var/lib/homedrive/<user>/
+  path: /var/lib/homedrive/fix/state.db
+  # systemd LogsDirectory=homedrive/%i creates /var/log/homedrive/<user>/
+  audit_log: /var/log/homedrive/fix/audit.jsonl
+
+http:
+  listen: 127.0.0.1:6090
+  metrics: true
+
+mqtt:
+  enabled: true
+  broker: tcp://192.168.1.2:1883
+  client_id_prefix: homedrive
+  base_topic: homedrive
+  ha_discovery_prefix: homeassistant
+  publish_interval: 30s
+  qos: 1
+
+logging:
+  level: info
+  format: json
+
+quota:
+  warn_pct: 90
+  stop_push_pct: 99
+
+dry_run: false

--- a/homedrive/linux/homedrive.default
+++ b/homedrive/linux/homedrive.default
@@ -1,6 +1,6 @@
 # /etc/default/homedrive
 # Variables consumed by systemd (homedrive@.service).
-# Rich config lives in HOMEDRIVE_CONFIG (YAML).
-HOMEDRIVE_CONFIG=/etc/homedrive/config.yaml
+# Per-user config lives at ~/.config/homedrive/config.yaml
+# (see /usr/share/doc/homedrive/config.yaml.example).
 HOMEDRIVE_LOG_LEVEL=info
 HOMEDRIVE_LOG=stderr

--- a/homedrive/linux/homedrive@.service
+++ b/homedrive/linux/homedrive@.service
@@ -10,18 +10,16 @@ User=%i
 Group=%i
 EnvironmentFile=/etc/default/homedrive
 EnvironmentFile=-/etc/default/homedrive.%i
-ExecStart=/usr/bin/homedrive run --config ${HOMEDRIVE_CONFIG}
+ExecStart=/usr/bin/homedrive run
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=10
 StateDirectory=homedrive/%i
 LogsDirectory=homedrive/%i
-ConfigurationDirectory=homedrive
 
 # hardening
 ProtectSystem=strict
 ProtectHome=read-only
-ReadOnlyPaths=/etc/homedrive
 PrivateTmp=true
 NoNewPrivileges=true
 ProtectKernelTunables=true

--- a/homedrive/linux/homedrive@.service
+++ b/homedrive/linux/homedrive@.service
@@ -5,7 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=notify
+Type=simple
 User=%i
 Group=%i
 EnvironmentFile=/etc/default/homedrive
@@ -14,7 +14,6 @@ ExecStart=/usr/bin/homedrive run --config ${HOMEDRIVE_CONFIG}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=10
-WatchdogSec=60
 StateDirectory=homedrive/%i
 LogsDirectory=homedrive/%i
 ConfigurationDirectory=homedrive

--- a/homedrive/linux/homedrive@.service
+++ b/homedrive/linux/homedrive@.service
@@ -10,6 +10,7 @@ User=%i
 Group=%i
 EnvironmentFile=/etc/default/homedrive
 EnvironmentFile=-/etc/default/homedrive.%i
+ExecCondition=/bin/sh -c 'test -f $(getent passwd %i | cut -d: -f6)/.config/homedrive/config.yaml'
 ExecStart=/usr/bin/homedrive run
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure

--- a/homedrive/linux/postinst.sh
+++ b/homedrive/linux/postinst.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 set -e
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# /etc/homedrive is created here; per-user state and log dirs are created by
+# /etc/homedrive is owned by root; per-user state and log dirs are created by
 # systemd at service start via StateDirectory=homedrive/%i / LogsDirectory=homedrive/%i.
 install -d -m 0755 -o root -g root /etc/homedrive
-install -m 0644 "$SCRIPT_DIR/99-homedrive-inotify.conf" /etc/sysctl.d/
-install -m 0644 "$SCRIPT_DIR/homedrive.logrotate" /etc/logrotate.d/homedrive
+# Apply inotify sysctl (file already placed by the package).
 sysctl --system
+systemctl daemon-reload

--- a/homedrive/linux/postinst.sh
+++ b/homedrive/linux/postinst.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
-# /etc/homedrive is owned by root; per-user state and log dirs are created by
-# systemd at service start via StateDirectory=homedrive/%i / LogsDirectory=homedrive/%i.
-install -d -m 0755 -o root -g root /etc/homedrive
+# Per-user config lives at ~/.config/homedrive/config.yaml.
+# Per-user state/log dirs are created by systemd at service start
+# via StateDirectory=homedrive/%i and LogsDirectory=homedrive/%i.
 # Apply inotify sysctl (file already placed by the package).
 sysctl --system
 systemctl daemon-reload


### PR DESCRIPTION
## Summary

- **runAgent wired end-to-end**: loads YAML config, opens BoltDB journal, initialises rclone Drive backend, starts Puller loop — replacing the previous no-op stub.
- **Initial sync**: first poll performs a full recursive remote walk, downloads every file to \`local_root\`, records transfers in the journal, persists a stable page token so subsequent 30s polls are no-ops.
- **Loop prevention**: \`DownloadFile\` preserves the remote mtime via \`os.Chtimes\`; the journal records \`local_mtime\` so the watcher will ignore the synthetic filesystem event.
- **Skip-unchanged fix**: \`processFileChange\` now compares \`ch.Object.ModTime\` vs \`journal.RemoteMtime\` within 1 s tolerance before re-downloading an already-synced file.
- **Per-user config at \`~/.config/homedrive/config.yaml\`**: \`ExecStart\` drops \`--config\`; binary resolves the path via \`os.UserConfigDir()\` at runtime. (\`%h\` in systemd system units always resolves to \`/root\` regardless of \`User=\`, so the resolution is deferred to the process.) Falls back to \`/etc/homedrive/config.yaml\` if \`$HOME\` is unavailable.
- **Packaging**: \`Type=notify\` → \`Type=simple\`; \`config.yaml.example\` shipped to \`/usr/share/doc/homedrive/\` (reference only, not \`config|noreplace\`); \`remote: "gdrive:"\` quoted to avoid YAML parse error; \`postinst.sh\` no longer creates \`/etc/homedrive\`.
- **Adapters**: \`adapters.go\` bridges \`*rcloneclient.RcloneFS\` and \`*store.Journal\` to the \`syncer.RemoteFS\` / \`syncer.Store\` interfaces without modifying internal packages.

## Test plan

- [ ] \`go test ./homedrive/...\` passes (all packages green, no race)
- [ ] Binary size < 25 MB: \`du -h dist/homedrive-arm64\`
- [ ] Exactly 1 rclone backend import
- [ ] \`homedrive@fix.service\` on gruissan: \`active (running)\`, 225 files in \`/home/fix/gdrive\`
- [ ] Second service restart: no files re-downloaded (page token = \`synced\`, journal populated)
- [ ] Config resolves to \`/home/fix/.config/homedrive/config.yaml\` (visible in startup log)