### PR TITLE
fix(mqtt): disable AutoReconnect on raw paho test clients

### DIFF
--- a/homedrive/internal/mqtt/discovery_test.go
+++ b/homedrive/internal/mqtt/discovery_test.go
@@ -276,7 +276,8 @@ func TestPublishDiscovery_RetainTrue(t *testing.T) {
 	opts := paho.NewClientOptions().
 		AddBroker(brokerAddr).
 		SetClientID("retain_verifier").
-		SetCleanSession(true)
+		SetCleanSession(true).
+		SetAutoReconnect(false)
 	verifier := paho.NewClient(opts)
 	token := verifier.Connect()
 	token.Wait()

--- a/homedrive/internal/mqtt/mqtt_test.go
+++ b/homedrive/internal/mqtt/mqtt_test.go
@@ -157,7 +157,8 @@ func TestNew_ConnectAndLWT(t *testing.T) {
 	received := make(chan string, 1)
 	subOpts := paho.NewClientOptions().
 		AddBroker(addr).
-		SetClientID("test-sub-lwt")
+		SetClientID("test-sub-lwt").
+		SetAutoReconnect(false)
 	subClient := paho.NewClient(subOpts)
 	tok := subClient.Connect()
 	if !tok.WaitTimeout(5 * time.Second) {
@@ -202,7 +203,8 @@ func TestPublishJSON_RoundTrip(t *testing.T) {
 	received := make(chan []byte, 1)
 	subOpts := paho.NewClientOptions().
 		AddBroker(addr).
-		SetClientID("test-sub-json")
+		SetClientID("test-sub-json").
+		SetAutoReconnect(false)
 	subClient := paho.NewClient(subOpts)
 	tok := subClient.Connect()
 	if !tok.WaitTimeout(5 * time.Second) {
@@ -419,7 +421,8 @@ func TestClose_Clean(t *testing.T) {
 	received := make(chan string, 2)
 	subOpts := paho.NewClientOptions().
 		AddBroker(addr).
-		SetClientID("test-sub-close")
+		SetClientID("test-sub-close").
+		SetAutoReconnect(false)
 	subClient := paho.NewClient(subOpts)
 	tok := subClient.Connect()
 	if !tok.WaitTimeout(5 * time.Second) {
@@ -553,7 +556,8 @@ func TestPublish_StringPayload(t *testing.T) {
 	received := make(chan string, 1)
 	subOpts := paho.NewClientOptions().
 		AddBroker(addr).
-		SetClientID("test-sub-string")
+		SetClientID("test-sub-string").
+		SetAutoReconnect(false)
 	subClient := paho.NewClient(subOpts)
 	tok := subClient.Connect()
 	if !tok.WaitTimeout(5 * time.Second) {


### PR DESCRIPTION
## Summary

CI run [29255912534](https://github.com/asnowfix/home-drive/actions/runs/29255912534) hung for 10 minutes in `TestClose_Clean` and failed with a `panic: test timed out after 10m0s`.

Root cause: bare `paho.NewClientOptions()` test clients default to `AutoReconnect: true`. When a test's embedded `mochi-mqtt` broker is closed in `t.Cleanup`, such a client can race a reconnect attempt into the broker's shutdown path, deadlocking on `mochi-mqtt`'s internal `Clients` RWMutex (`attachClient`'s write lock vs. `closeListenerClients`'s read lock during `Server.Close()`). The test only recovers when the whole test binary's 10-minute timeout fires.

## Fix

Disable `AutoReconnect` on all 5 raw `paho.NewClientOptions()` test client construction sites in `internal/mqtt` (`mqtt_test.go` x4, `discovery_test.go` x1). Test subscribers don't need reconnect behavior; production code (`mqtt.go`) is untouched and still uses `AutoReconnect(true)` as intended.

## Test plan

- [x] `go build ./homedrive/...`
- [x] `go vet ./homedrive/internal/mqtt/...`
- [x] `go test -race -count=5 -timeout=120s ./homedrive/internal/mqtt/...` — 5x clean, no hangs
- [x] `go test -race -timeout=180s ./homedrive/...` — full suite green