### PR TITLE
docs: add v0.1.1 release notes + tag-triggered draft release CI

### DIFF
--- a/.github/workflows/homedrive-release.yml
+++ b/.github/workflows/homedrive-release.yml
@@ -20,6 +20,35 @@ jobs:
         with:
           go-version: '1.26'
 
+      # GoReleaser OSS has no way to strip a "homedrive/" tag prefix (that's
+      # a Pro-only "monorepo" feature), and its git-state check requires a
+      # tag literally named after the version it parses. So we create local,
+      # unpushed shadow tags ("homedrive/v0.1.1" -> "v0.1.1") pointing at the
+      # same commits as the real prefixed tags, and point GoReleaser at those
+      # via GORELEASER_CURRENT_TAG/GORELEASER_PREVIOUS_TAG. Nothing here is
+      # ever pushed back to origin.
+      - name: Compute shadow version tags
+        run: |
+          set -euo pipefail
+          current_prefixed="${GITHUB_REF_NAME}"
+          current="${current_prefixed#homedrive/}"
+
+          previous_prefixed=$(git tag -l 'homedrive/v*' --sort=-v:refname \
+            | grep -A1 -F -x "${current_prefixed}" | tail -1)
+          if [ "${previous_prefixed}" = "${current_prefixed}" ]; then
+            previous_prefixed=""
+          fi
+
+          git tag -a -m "shadow tag for goreleaser" "${current}" "${GITHUB_SHA}"
+          echo "GORELEASER_CURRENT_TAG=${current}" >> "$GITHUB_ENV"
+
+          if [ -n "${previous_prefixed}" ]; then
+            previous="${previous_prefixed#homedrive/}"
+            previous_commit=$(git rev-list -n1 "${previous_prefixed}")
+            git tag -a -m "shadow tag for goreleaser" "${previous}" "${previous_commit}"
+            echo "GORELEASER_PREVIOUS_TAG=${previous}" >> "$GITHUB_ENV"
+          fi
+
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/.github/workflows/homedrive-release.yml
+++ b/.github/workflows/homedrive-release.yml
@@ -1,0 +1,29 @@
+name: homedrive-release
+
+on:
+  push:
+    tags:
+      - "homedrive/v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
 
 nfpms:
   - id: homedrive
-    builds:
+    ids:
       - homedrive
     package_name: homedrive
     vendor: asnowfix
@@ -55,10 +55,11 @@ nfpms:
 
 archives:
   - id: homedrive
-    builds:
+    ids:
       - homedrive
     name_template: "homedrive_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
+    formats:
+      - tar.gz
 
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 version: 2
 
+release:
+  draft: true
+
 builds:
   - id: homedrive
     main: ./homedrive/cmd/homedrive

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release notes
 
+## homedrive v0.1.1
+
+Maintenance release. No functional changes to the sync engine, CLI, or MQTT
+wire protocol since v0.1.0.
+
+### Fixed
+
+- MQTT test suite: eliminated an intermittent CI hang where raw paho test
+  clients' `AutoReconnect` could race the embedded mochi-mqtt broker's
+  shutdown, deadlocking on its `Clients` RWMutex (#38).
+
+### Documentation
+
+- Refreshed the root `README.md` to reflect v0.1.0 released status.
+- Removed stale, duplicate root-level `PLAN.md` and `docs/architecture.md` /
+  `docs/dev-environment.md` scaffolding, superseded by `homedrive/PLAN.md`
+  and `homedrive/docs/` (#39).
+
+### Upgrade path
+
+No action required. Drop-in replacement for v0.1.0; no config, schema, or
+wire-protocol changes.
+
 ## homedrive v0.1.0
 
 First tagged release of homedrive, a bidirectional Google Drive sync agent


### PR DESCRIPTION
## Summary
- Adds a `homedrive v0.1.1` section to RELEASE_NOTES.md covering the two commits merged since v0.1.0:
  - #38 fix(mqtt): disable AutoReconnect on raw paho test clients (CI hang fix)
  - #39 docs: reflect v0.1.0 release status, drop stale planning docs
- No functional/production code changes in this range; v0.1.1 is a maintenance release.
- Adds `.github/workflows/homedrive-release.yml`, triggered by pushing a `homedrive/vX.Y.Z` tag, which runs `goreleaser` to build linux/amd64 + linux/arm64 binaries, `.deb` packages, and archives, and publishes them as a **draft** GitHub Release.
- Fixes goreleaser config: `release.draft: true`, plus pending `archives.formats`/`archives.ids`/`nfpms.ids` deprecation cleanups.
- Since GoReleaser OSS has no way to strip a tag prefix like `homedrive/` (that's a Pro-only "monorepo" feature), the workflow creates local, unpushed "shadow" tags (`homedrive/vX.Y.Z` → `vX.Y.Z`) pointing at the same commits, and points GoReleaser at those via `GORELEASER_CURRENT_TAG`/`GORELEASER_PREVIOUS_TAG`. Nothing is ever pushed back to origin — the real, signed `homedrive/vX.Y.Z` tag stays the only one that exists upstream.

## Test plan
- [x] `goreleaser check` passes with no deprecation warnings
- [x] Local dry run (`goreleaser release --clean --skip=publish,announce,sign` with shadow tags simulating the real CI flow) produces correctly versioned `homedrive_0.1.1_linux_{amd64,arm64}.{tar.gz,deb}` artifacts and a changelog scoped to homedrive/v0.1.0..homedrive/v0.1.1
- [ ] After merge: push tag `homedrive/v0.1.1` and confirm the `homedrive-release` workflow creates a draft GitHub Release with the 4 artifacts attached