### PR TITLE
ci: use lightweight shadow tags in release workflow

### DIFF
--- a/.github/workflows/homedrive-release.yml
+++ b/.github/workflows/homedrive-release.yml
@@ -39,13 +39,15 @@ jobs:
             previous_prefixed=""
           fi
 
-          git tag -a -m "shadow tag for goreleaser" "${current}" "${GITHUB_SHA}"
+          # Lightweight (unannotated) tags: no committer identity required,
+          # and goreleaser only needs them to resolve to the right commits.
+          git tag "${current}" "${GITHUB_SHA}"
           echo "GORELEASER_CURRENT_TAG=${current}" >> "$GITHUB_ENV"
 
           if [ -n "${previous_prefixed}" ]; then
             previous="${previous_prefixed#homedrive/}"
             previous_commit=$(git rev-list -n1 "${previous_prefixed}")
-            git tag -a -m "shadow tag for goreleaser" "${previous}" "${previous_commit}"
+            git tag "${previous}" "${previous_commit}"
             echo "GORELEASER_PREVIOUS_TAG=${previous}" >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
## Summary
- Fixes #41's `homedrive-release` workflow: the first real run (tag `homedrive/v0.1.1`) failed at "Compute shadow version tags" with `fatal: empty ident name ... not allowed`, because GitHub Actions runners have no git committer identity configured and the shadow tags were being created as annotated (`git tag -a -m ...`).
- Switches to lightweight tags (`git tag NAME COMMIT`, no `-a`/`-m`), which require no identity and work identically for goreleaser's tag resolution.

## Test plan
- [x] Locally simulated the exact failure (`git -c tag.gpgsign=true tag -a -m ... ...` reproduces "no tag message?"/identity errors)
- [x] Locally verified lightweight tags (with `tag.gpgsign` unset, matching CI default) let `goreleaser release` succeed end-to-end, producing correctly versioned `homedrive_0.1.1_linux_{amd64,arm64}.{tar.gz,deb}`
- [ ] After merge: re-push tag `homedrive/v0.1.1` and confirm `homedrive-release` completes and publishes a draft GitHub Release