### PR TITLE
ci: re-point published release at the real prefixed tag

### DIFF
--- a/.github/workflows/homedrive-release.yml
+++ b/.github/workflows/homedrive-release.yml
@@ -58,3 +58,12 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GoReleaser publishes the GitHub Release under the shadow tag (e.g.
+      # "v0.1.1") since that's the only tag it knows about. Re-point it at
+      # the real, pushed tag so the release page links to a tag that
+      # actually exists in the repo.
+      - name: Re-tag release to the real prefixed tag
+        run: gh release edit "${GORELEASER_CURRENT_TAG}" --tag "${GITHUB_REF_NAME}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- v0.1.1's `homedrive-release` run published a draft GitHub Release tagged `v0.1.1` instead of `homedrive/v0.1.1`, since goreleaser only knows about the local shadow tag used to work around its Pro-only monorepo/tag-prefix support. `v0.1.1` was never pushed and doesn't exist as a real tag in the repo, so the release page's tag link was dangling.
- Manually fixed the existing v0.1.1 release via `gh release edit v0.1.1 --tag homedrive/v0.1.1`.
- Adds an automated step so future releases re-point themselves at the real tag right after goreleaser publishes.

## Test plan
- [x] Manually verified `gh release edit <shadow-tag> --tag <real-tag>` correctly re-targets a draft release (done for v0.1.1) without touching its assets or draft status
- [ ] Next release (v0.1.2+) will validate the automated step end-to-end