### PR TITLE
ci: add Dependabot auto-merge for patch/minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,26 @@ updates:
     directory: "/homedrive"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     groups:
-      rclone:
-        patterns:
-          - "github.com/rclone/rclone*"
+      # Patch/minor bumps are low-risk and grouped into one PR so they can
+      # auto-merge together (see dependabot-auto-merge.yml). Major bumps are
+      # excluded: each lands as its own PR and is never auto-merged. CI still
+      # gates every merge on the <25 MB binary-size and single-rclone-backend
+      # checks, so a size/backend-breaking minor bump fails CI, not silently
+      # merges.
+      go-minor-patch:
         update-types:
           - "minor"
           - "patch"
-      mqtt:
-        patterns:
-          - "github.com/eclipse/paho.mqtt.golang"
-          - "github.com/mochi-mqtt/*"
-      go-stdlib-adjacent:
-        patterns:
-          - "golang.org/x/*"
-    open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Arms GitHub native auto-merge on Dependabot PRs for patch/minor updates only.
+# Auto-merge waits for all required status checks (build/test/lint from
+# homedrive.yml) to pass — it does not bypass CI. Major bumps are excluded from
+# the grouped patch/minor PRs in dependabot.yml, so they arrive as separate PRs
+# that never match the update-type check below and require a manual merge.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/homedrive.yml
+++ b/.github/workflows/homedrive.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "homedrive/**"
-      - ".github/workflows/homedrive.yml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Regroups `.github/dependabot.yml` by update-type (`go-minor-patch` / `actions-minor-patch`) instead of by library, matching `asnowfix/home-automation`'s setup (commit `bd1a3c9`). Major bumps always land as separate, manually-reviewed PRs.
- Adds `.github/workflows/dependabot-auto-merge.yml`: arms native GitHub auto-merge on Dependabot PRs once `dependabot/fetch-metadata` reports `version-update:semver-patch` or `version-update:semver-minor`. Auto-merge still waits on `homedrive.yml`'s required status checks — it doesn't bypass CI.
- Broadens `homedrive.yml`'s `pull_request` path filter from `.github/workflows/homedrive.yml` to `.github/workflows/**`, so a Dependabot `github-actions` PR that only touches the new auto-merge workflow still triggers the required checks (otherwise auto-merge would wait forever on checks that never run).

Repo-level settings (`allow_auto_merge`, branch protection on `main` requiring `build (amd64)`, `build (arm64)`, `test (amd64)`, `lint (amd64)`, vulnerability alerts, and Dependabot security updates) are **not** version-controlled — applied separately via `gh api` after this merges, per the issue's audit.

Closes #40

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on all three changed/added YAML files — parses cleanly
- [x] Diff reviewed against the home-automation reference implementation
- [ ] After merge: apply the `gh api` settings (auto-merge, branch protection, security alerts) and verify the next Dependabot PR triggers checks, arms auto-merge, and self-merges when green